### PR TITLE
Unpin requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible>=2.8.0
-graphviz==0.16
-colour==0.1.5
-lxml==4.6.2
-packaging==20.9
+graphviz<1
+colour<1
+lxml<5
+packaging


### PR DESCRIPTION
lxml has a security release in version 4.6.3, however I cannot upgrade to it due to ansible-playbook-grapher pinning it directly. As an installable tool that can interact with a virtualenv, ansible-playbook-grapher should not pin dependencies but declare ranges up until the next backwards-incompatible version, to allow users to fetch such upgrades.