### PR TITLE
fix: Drop support for ansible 2.9, 2.10 and add ansible 2.11.6

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Tests Py${{ matrix.python-version }} - Ansible ${{ matrix.ansible-version }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ 3.7, 3.8 ]
         # See https://www.ansible.com/blog/ansible-3.0.0-qa and https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [ 3.8, 3.9 ]
         # See https://www.ansible.com/blog/ansible-3.0.0-qa and https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
         ansible-version: [ 2.11.6, 2.12.0 ]
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,9 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.7, 3.8 ]
-        ansible-version: [ 2.9.14, 2.10.7 ]
+        # See https://www.ansible.com/blog/ansible-3.0.0-qa and https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
+        # TODO: replace ansible-base by ansible-core when dropping support for ansible <= 2.10 (the package have been renamed)
+        ansible-version: [ ansible-base==2.10.7, ansible-core==2.11.6 ]
 
     steps:
       - name: Checkout code
@@ -28,7 +30,7 @@ jobs:
 
       - name: Install prereqs
         run: |
-          pip install ansible==${{ matrix.ansible-version }} virtualenv setuptools wheel coveralls
+          pip install ${{ matrix.ansible-version }} virtualenv setuptools wheel coveralls
           pip install -r tests/requirements_tests.txt
           pip freeze
           sudo apt-get install -y graphviz
@@ -41,7 +43,7 @@ jobs:
       - name: Upload generated SVGs as artefacts
         uses: actions/upload-artifact@v2
         with:
-          name: generated-svgs-py${{ matrix.python-version }}-ansible${{ matrix.ansible-version }}
+          name: generated-svgs-py${{ matrix.python-version }}-${{ matrix.ansible-version }}
           path: tests/generated_svg/
           if-no-files-found: error # the tests should generate SVGs files
 
@@ -52,7 +54,7 @@ jobs:
         run: cd tests && coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: py${{ matrix.python-version }}-ansible${{ matrix.ansible-version }}
+          COVERALLS_FLAG_NAME: py${{ matrix.python-version }}-${{ matrix.ansible-version }}
           COVERALLS_PARALLEL: true
 
   coveralls:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         python-version: [ 3.7, 3.8 ]
         # See https://www.ansible.com/blog/ansible-3.0.0-qa and https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
-        ansible-version: [ 2.11.6 ]
+        ansible-version: [ 2.11.6, 2.12.0 ]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -47,7 +47,7 @@ jobs:
           if-no-files-found: error # the tests should generate SVGs files
 
       - name: Test installation in virtualenv
-        run: make test_install
+        run: make test_install ANSIBLE_VERSION=${{ matrix.ansible-version }}
 
       - name: Upload Coverage
         run: cd tests && coveralls --service=github

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,8 +16,7 @@ jobs:
       matrix:
         python-version: [ 3.7, 3.8 ]
         # See https://www.ansible.com/blog/ansible-3.0.0-qa and https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
-        # TODO: replace ansible-base by ansible-core when dropping support for ansible <= 2.10 (the package have been renamed)
-        ansible-version: [ ansible-base==2.10.7, ansible-core==2.11.6 ]
+        ansible-version: [ 2.11.6 ]
 
     steps:
       - name: Checkout code
@@ -30,7 +29,7 @@ jobs:
 
       - name: Install prereqs
         run: |
-          pip install ${{ matrix.ansible-version }} virtualenv setuptools wheel coveralls
+          pip install ansible-core==${{ matrix.ansible-version }} virtualenv setuptools wheel coveralls
           pip install -r tests/requirements_tests.txt
           pip freeze
           sudo apt-get install -y graphviz
@@ -43,7 +42,7 @@ jobs:
       - name: Upload generated SVGs as artefacts
         uses: actions/upload-artifact@v2
         with:
-          name: generated-svgs-py${{ matrix.python-version }}-${{ matrix.ansible-version }}
+          name: generated-svgs-py${{ matrix.python-version }}-ansible${{ matrix.ansible-version }}
           path: tests/generated_svg/
           if-no-files-found: error # the tests should generate SVGs files
 
@@ -54,7 +53,7 @@ jobs:
         run: cd tests && coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: py${{ matrix.python-version }}-${{ matrix.ansible-version }}
+          COVERALLS_FLAG_NAME: py${{ matrix.python-version }}-ansible${{ matrix.ansible-version }}
           COVERALLS_PARALLEL: true
 
   coveralls:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,34 +3,36 @@
 - refactor: See [\#81](https://github.com/haidaraM/ansible-playbook-grapher/pull/81)
     - Completely rewrite the grapher: the parser, the graph and the renderer to graphviz have been split.
     - Hide some ansible internals in the parser.
-    - Clean code.
 - feat:
-  - Consider inclue_role as normal role instead of
-    task [\#82](https://github.com/haidaraM/ansible-playbook-grapher/pull/82)
-  - feat: Curved edge label based on the path [\#84](https://github.com/haidaraM/ansible-playbook-grapher/pull/84)
-  - feat: Add option to automatically view the generated
-    file [\#88](https://github.com/haidaraM/ansible-playbook-grapher/pull/88)
-  - feat: Add support for block [\#86](https://github.com/haidaraM/ansible-playbook-grapher/pull/86)
-  - Add support for when on include_role
+    - Consider include_role as normal role instead of
+      task [\#82](https://github.com/haidaraM/ansible-playbook-grapher/pull/82)
+    - feat: Curved edge label based on the path [\#84](https://github.com/haidaraM/ansible-playbook-grapher/pull/84)
+    - feat: Add option to automatically view the generated
+      file [\#88](https://github.com/haidaraM/ansible-playbook-grapher/pull/88)
+    - feat: Add support for block [\#86](https://github.com/haidaraM/ansible-playbook-grapher/pull/86). They are now
+      visible in the graph.
+    - Add support for when on include_role.
+    - Only Ansible >= 2.11 is supported. **Python >=3.8** is now
+      required [\#94](https://github.com/haidaraM/ansible-playbook-grapher/pull/94).
 - fix:
-  - front: Refactor the JS part and fix issue when selecting/unselecting nodes
-  - front: Do not unhighlight the current selected node when hovering on parent node
-  - cli(typo): rename `--ouput-file-name` to `--output-file-name`
-  - Use the correct tooltip for edges
-  - style: Do not use bold style by default and apply color on nodes border
-  - Merge when condition with `and`
-  - Explicitly set color luminance to avoid bright colors
-  - Reduce Node ID lengths. No need to use the full UUID
-  - Make grapher works with graphviz >= 0.18. See [\#91](https://github.com/haidaraM/ansible-playbook-grapher/issues/91)
+    - front: Refactor the JS part and fix issue when selecting/unselecting nodes
+    - front: Do not unhighlight the current selected node when hovering on parent node
+    - cli(typo): rename `--ouput-file-name` to `--output-file-name`
+    - Use the correct tooltip for edges
+    - style: Do not use bold style by default and apply color on nodes border
+    - Merge when condition with `and`
+    - Explicitly set color luminance to avoid bright colors
+    - Reduce Node ID lengths. No need to use the full UUID
+    - Make grapher works with graphviz >= 0.18.
+      See [\#91](https://github.com/haidaraM/ansible-playbook-grapher/issues/91)
 - test:
-  - Add Ansible 2.10.7 in the test matrix
-  - Make test verbose by default with `-vv` in the args
+    - Make test verbose by default with `-vv` in the args
+    - Fix test_install in GitHub Actions which was not using the correct Ansible version.
 - docs:
-  - Reformat CHANGELOG
-  - Reformat README.md
+    - Reformat CHANGELOG.md and README.md
 - Dependencies:
-  - bump pytest from 6.2.4 to 6.2.5 [\#83](https://github.com/haidaraM/ansible-playbook-grapher/pull/83)
-  - bump pytest-cov from 2.12.1 to 3.0.0 [\#90](https://github.com/haidaraM/ansible-playbook-grapher/pull/90)
+    - bump pytest from 6.2.4 to 6.2.5 [\#83](https://github.com/haidaraM/ansible-playbook-grapher/pull/83)
+    - bump pytest-cov from 2.12.1 to 3.0.0 [\#90](https://github.com/haidaraM/ansible-playbook-grapher/pull/90)
 
 # 0.11.2 (2021-11-07)
 
@@ -39,10 +41,10 @@
 # 0.11.1 (2021-07-28)
 
 - Dependencies:
-  - Unpin requirements. See [\#71](https://github.com/haidaraM/ansible-playbook-grapher/issues/71)
-  - Bump pytest-cov from 2.11.1 to 2.12.1 [\#78](https://github.com/haidaraM/ansible-playbook-grapher/issues/78)
-  - Bump pytest from 6.2.2 to 6.2.4 [\#76](https://github.com/haidaraM/ansible-playbook-grapher/issues/76)
-  - Upgrade to GitHub-native Dependabot [\#72](https://github.com/haidaraM/ansible-playbook-grapher/issues/72)
+    - Unpin requirements. See [\#71](https://github.com/haidaraM/ansible-playbook-grapher/issues/71)
+    - Bump pytest-cov from 2.11.1 to 2.12.1 [\#78](https://github.com/haidaraM/ansible-playbook-grapher/issues/78)
+    - Bump pytest from 6.2.2 to 6.2.4 [\#76](https://github.com/haidaraM/ansible-playbook-grapher/issues/76)
+    - Upgrade to GitHub-native Dependabot [\#72](https://github.com/haidaraM/ansible-playbook-grapher/issues/72)
 - Drop support for ansible 2.8. **The grapher requires at least ansible
   2.9** [\#74](https://github.com/haidaraM/ansible-playbook-grapher/issues/74)
 - Fix:
@@ -64,7 +66,7 @@
     - Rewriting the grapher, clean code.
     - Generate node IDs from an util function
 - Style: Replace some `format` by f-string
-- CI: Replace Travis by Github actions (#54)
+- CI: Replace Travis by GitHub actions (#54)
 - Dependencies:
     - Bump pytest from 6.0.1 to 6.2.2 (PRs #50, #51, #62, #67)
     - Bump pytest-cov from 2.10.0 to 2.11.1 (PRs #49, #65)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ANSIBLE_VERSION=2.9
+ANSIBLE_VERSION=2.10.7
 VIRTUALENV_DIR=venv
 PACKAGE := dist/$(shell ls dist 2> /dev/null)
 SRC=$(wildcard ansibleplaybookgrapher/*.py setup.py ansibleplaybookgrapher/data/*)

--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ Inspired by [Ansible Inventory Grapher](https://github.com/willthames/ansible-in
 ## Prerequisites
 
 - Python 3
-- **Ansible** >= 2.10: If you still use an older version of Ansible, create a virtual environment and install
-  ansible-playbook-grapher.
-  **pip will install a version of Ansible >= 2.10 if not already installed.**
-  I try to respect [Red Hat Ansible Engine Life Cycle](https://access.redhat.com/support/policy/updates/ansible-engine)
-  for the supported Ansible version.
+- A virtual environment from which to run the grapher. This is **highly recommended** because the grapher depends on
+  some versions of ansible-core which are not necessarily installed in your environment and may cause issues if you use
+  some older versions of Ansible.
 - **Graphviz**: The tool used to generate the graph in SVG.
   ```shell script
   $ sudo apt-get install graphviz # or yum install or brew install
   ```
+
+I try to respect [Red Hat Ansible Engine Life Cycle](https://access.redhat.com/support/policy/updates/ansible-engine)
+for the supported Ansible version.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Inspired by [Ansible Inventory Grapher](https://github.com/willthames/ansible-in
 ## Prerequisites
 
 - Python 3
-- **Ansible** >= 2.9: If you still use an older version of Ansible, create a virtual environment and install
+- **Ansible** >= 2.10: If you still use an older version of Ansible, create a virtual environment and install
   ansible-playbook-grapher.
-  **pip will install a version of Ansible >= 2.9 if not already installed.** I try to
-  respect [Red Hat Ansible Engine Life Cycle](https://access.redhat.com/support/policy/updates/ansible-engine) for the
-  supported Ansible version.
+  **pip will install a version of Ansible >= 2.10 if not already installed.**
+  I try to respect [Red Hat Ansible Engine Life Cycle](https://access.redhat.com/support/policy/updates/ansible-engine)
+  for the supported Ansible version.
 - **Graphviz**: The tool used to generate the graph in SVG.
   ```shell script
   $ sudo apt-get install graphviz # or yum install or brew install

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Inspired by [Ansible Inventory Grapher](https://github.com/willthames/ansible-in
 
 ## Prerequisites
 
-- Python 3
+- Python 3.8 at least
 - A virtual environment from which to run the grapher. This is **highly recommended** because the grapher depends on
   some versions of ansible-core which are not necessarily installed in your environment and may cause issues if you use
   some older versions of Ansible.

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -7,16 +7,11 @@ from ansible.cli import CLI
 from ansible.cli.arguments import option_helpers
 from ansible.release import __version__ as ansible_version
 from ansible.utils.display import Display
-from packaging import version
 
 from ansibleplaybookgrapher import __prog__, __version__
 from ansibleplaybookgrapher.parser import PlaybookParser
 from ansibleplaybookgrapher.postprocessor import GraphVizPostProcessor
 from ansibleplaybookgrapher.renderer import GraphvizRenderer
-
-# At some time, we needed to know if we are using ansible 2.8 because the CLI has been refactored in this PR:
-# https://github.com/ansible/ansible/pull/50069
-IS_ANSIBLE_2_9_X = version.parse(ansible_version) >= version.parse("2.9")
 
 
 def get_cli_class():
@@ -61,7 +56,7 @@ class GrapherCLI(CLI, ABC):
 
 class PlaybookGrapherCLI(GrapherCLI):
     """
-    The dedicated playbook CLI for Ansible 2.9 and above (for the moment)
+    The dedicated playbook grapher CLI
     """
 
     def __init__(self, args, callback=None):

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -68,6 +68,10 @@ class BaseParser(ABC):
         :return: True if the task has been included, false otherwise
         """
 
+        # Ansible-core 2.11 added an implicit meta tasks at the end of the role. So wee skip it here.
+        if task.action == "meta" and task.implicit:
+            return False
+
         if not task.evaluate_tags(only_tags=self.tags, skip_tags=self.skip_tags, all_vars=task_vars):
             self.display.vv(f"The task '{task.get_name()}' is skipped due to the tags.")
             return False

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -3,7 +3,6 @@ import uuid
 from typing import Tuple, List
 
 from ansible.parsing.dataloader import DataLoader
-from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.playbook import Play
 from ansible.playbook.role_include import IncludeRole
 from ansible.playbook.task import Task
@@ -12,14 +11,18 @@ from ansible.template import Templar
 from colour import Color
 
 
-def convert_when_to_str(when: List[AnsibleUnicode]) -> str:
+def convert_when_to_str(when: List) -> str:
     """
     Convert ansible conditional when to str
     :param when:
     :return:
     """
+    if len(when) == 0:
+        return ""
 
-    return f"[when: {' and '.join(when)}]" if len(when) > 0 else ""
+    # Convert each element in the list to str
+    when_to_str = list(map(str, when))
+    return f"[when: {' and '.join(when_to_str)}]"
 
 
 def generate_id(prefix: str = "") -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.10
+ansible-core>=2.11,<3
 graphviz>=0.18,<1
 colour<1
 lxml<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible>=2.9.0
+ansible>=2.10
 graphviz>=0.18,<1
 colour<1
 lxml<5

--- a/test_install.sh
+++ b/test_install.sh
@@ -19,13 +19,11 @@ virtualenv --clear ${VIRTUALENV_DIR}
 
 source ${VIRTUALENV_DIR}/bin/activate
 
-pip -V
-
 package=dist/$(ls dist)
 
 echo -e "${GREEN}Installing the packages ${package} and ansible ${ANSIBLE_VERSION} ${NC}"
 
-pip install -q ${package} ansible==${ANSIBLE_VERSION}
+pip install -q ${package} ansible-core==${ANSIBLE_VERSION}
 
 ${VIRTUALENV_DIR}/bin/ansible-playbook-grapher --version
 ${VIRTUALENV_DIR}/bin/ansible-playbook-grapher tests/fixtures/example.yml


### PR DESCRIPTION
Since the [Ansible package have been split](https://www.ansible.com/blog/ansible-3.0.0-qa), this PR removes the old version and keep only `ansible-core` since it's the only package the grapher needs. 

As such, the minimum required version is now **ansible-core >= 2.11** and **python 3.8**