### PR TITLE
refactor(internal): Remove useless EdgeNode

### DIFF
--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -25,6 +25,9 @@ function highlightLinkedNodes(rootElement) {
         let currentElement = $('#' + target);
         currentElement.addClass(HIGHLIGHT_CLASS);
 
+        // Highlight the edge point to the target
+        $('#edge_' + target).addClass(HIGHLIGHT_CLASS);
+
         // Recursively highlight
         highlightLinkedNodes(currentElement);
     })
@@ -47,8 +50,10 @@ function unHighlightLinkedNodes(rootElement, isHover) {
             let linkedElementId = $(element).attr('target');
             let linkedElement = $('#' + linkedElementId);
 
-            if (linkedElement.attr("id") !== currentSelectedElementId) {
+            if (linkedElement.attr('id') !== currentSelectedElementId) {
                 linkedElement.removeClass(HIGHLIGHT_CLASS);
+                // Unhighlight the edge point to the target
+                $('#edge_' + linkedElementId).removeClass(HIGHLIGHT_CLASS);
                 // Recursively unhighlight
                 unHighlightLinkedNodes(linkedElement, isHover);
             }

--- a/ansibleplaybookgrapher/graph.py
+++ b/ansibleplaybookgrapher/graph.py
@@ -24,16 +24,18 @@ class Node:
     A node in the graph. Everything of the final graph is a node: playbook, plays, edges, tasks and roles.
     """
 
-    def __init__(self, node_name: str, node_id: str, raw_object=None):
+    def __init__(self, node_name: str, node_id: str, when: str = "", raw_object=None):
         """
 
         :param node_name: The name of the node
         :param node_id: An identifier for this node
+        :param when: The conditional attached to the node
         :param raw_object: The raw ansible object matching this node in the graph. Will be None if there is no match on
         Ansible side
         """
         self.name = node_name
         self.id = node_id
+        self.when = when
         self.raw_object = raw_object
         # Trying to get the object position in the parsed files. Format: (path,line,column)
         self.path = self.line = self.column = None
@@ -69,6 +71,7 @@ class CompositeNode(Node):
         self,
         node_name: str,
         node_id: str,
+        when: str = "",
         raw_object=None,
         supported_compositions: List[str] = None,
     ):
@@ -80,7 +83,7 @@ class CompositeNode(Node):
         Ansible side
         :param supported_compositions:
         """
-        super().__init__(node_name, node_id, raw_object)
+        super().__init__(node_name, node_id, when, raw_object)
         self._supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition.
         self._compositions = defaultdict(list)  # type: Dict[str, List]
@@ -106,6 +109,29 @@ class CompositeNode(Node):
             )
         self._compositions[target_composition].append(node)
 
+    def get_all_tasks(self) -> List["TaskNode"]:
+        """
+        Return all the TaskNode inside a composite node
+        :return:
+        """
+        tasks: List[TaskNode] = []
+        self._get_all_tasks_nodes(tasks)
+        return tasks
+
+    def _get_all_tasks_nodes(self, task_acc: List["Node"]):
+        """
+
+        :param task_acc:
+        :return:
+        """
+        items = self.items()
+        for _, nodes in items:
+            for node in nodes:
+                if isinstance(node, TaskNode):
+                    task_acc.append(node)
+                elif isinstance(node, CompositeNode):
+                    node._get_all_tasks_nodes(task_acc)
+
     def links_structure(self) -> Dict[Node, List[Node]]:
         """
         Return a representation of the composite node where each key of the dictionary is the node and the value is the
@@ -130,11 +156,11 @@ class CompositeNode(Node):
 
 class CompositeTasksNode(CompositeNode):
     """
-    A special composite node which only support adding "tasks"
+    A special composite node which only support adding "tasks". Useful for block and role
     """
 
-    def __init__(self, node_name: str, node_id: str, raw_object=None):
-        super().__init__(node_name, node_id, raw_object=raw_object)
+    def __init__(self, node_name: str, node_id: str, when: str = "", raw_object=None):
+        super().__init__(node_name, node_id, when=when, raw_object=raw_object)
         self._supported_compositions = ["tasks"]
 
     def add_node(self, target_composition: str, node: Node):
@@ -147,7 +173,7 @@ class CompositeTasksNode(CompositeNode):
         super().add_node("tasks", node)
 
     @property
-    def tasks(self) -> List["EdgeNode"]:
+    def tasks(self) -> List[Node]:
         """
         The tasks attached to this block
         :return:
@@ -160,10 +186,13 @@ class PlaybookNode(CompositeNode):
     A playbook is a list of play
     """
 
-    def __init__(self, node_name: str, node_id: str = None, raw_object=None):
+    def __init__(
+        self, node_name: str, node_id: str = None, when: str = "", raw_object=None
+    ):
         super().__init__(
             node_name,
             node_id or generate_id("playbook_"),
+            when=when,
             raw_object=raw_object,
             supported_compositions=["plays"],
         )
@@ -179,23 +208,12 @@ class PlaybookNode(CompositeNode):
         self.column = 1
 
     @property
-    def plays(self) -> List["EdgeNode"]:
+    def plays(self) -> List["PlayNode"]:
         """
         Return the list of plays
         :return:
         """
         return self._compositions["plays"]
-
-    def add_play(self, play: "PlayNode", edge_name: str, **kwargs) -> "EdgeNode":
-        """
-        Add a play to the playbook
-        :param play:
-        :param edge_name:
-        :return:
-        """
-        edge = EdgeNode(self, play, edge_name)
-        self.add_node("plays", edge)
-        return edge
 
 
 class PlayNode(CompositeNode):
@@ -211,6 +229,7 @@ class PlayNode(CompositeNode):
         self,
         node_name: str,
         node_id: str = None,
+        when: str = "",
         raw_object=None,
         hosts: List[str] = None,
     ):
@@ -222,25 +241,26 @@ class PlayNode(CompositeNode):
         super().__init__(
             node_name,
             node_id or generate_id("play_"),
+            when=when,
             raw_object=raw_object,
             supported_compositions=["pre_tasks", "roles", "tasks", "post_tasks"],
         )
         self.hosts = hosts or []
 
     @property
-    def roles(self) -> List["EdgeNode"]:
+    def roles(self) -> List["RoleNode"]:
         return self._compositions["roles"]
 
     @property
-    def pre_tasks(self) -> List["EdgeNode"]:
+    def pre_tasks(self) -> List["Node"]:
         return self._compositions["pre_tasks"]
 
     @property
-    def post_tasks(self) -> List["EdgeNode"]:
+    def post_tasks(self) -> List["Node"]:
         return self._compositions["post_tasks"]
 
     @property
-    def tasks(self) -> List["EdgeNode"]:
+    def tasks(self) -> List["Node"]:
         return self._compositions["tasks"]
 
 
@@ -249,9 +269,14 @@ class BlockNode(CompositeTasksNode):
     A block node: https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html
     """
 
-    def __init__(self, node_name: str, node_id: str = None, raw_object=None):
+    def __init__(
+        self, node_name: str, node_id: str = None, when: str = "", raw_object=None
+    ):
         super().__init__(
-            node_name, node_id or generate_id("block_"), raw_object=raw_object
+            node_name,
+            node_id or generate_id("block_"),
+            when=when,
+            raw_object=raw_object,
         )
 
 
@@ -305,14 +330,18 @@ class TaskNode(Node):
     A task node. Can be pre_task, task or post_task
     """
 
-    def __init__(self, node_name: str, node_id: str = None, raw_object=None):
+    def __init__(
+        self, node_name: str, node_id: str = None, when: str = "", raw_object=None
+    ):
         """
 
         :param node_name:
         :param node_id:
         :param raw_object:
         """
-        super().__init__(node_name, node_id or generate_id("task_"), raw_object)
+        super().__init__(
+            node_name, node_id or generate_id("task_"), when=when, raw_object=raw_object
+        )
 
 
 class RoleNode(CompositeTasksNode):
@@ -324,6 +353,7 @@ class RoleNode(CompositeTasksNode):
         self,
         node_name: str,
         node_id: str = None,
+        when: str = "",
         raw_object=None,
         include_role: bool = False,
     ):
@@ -334,36 +364,10 @@ class RoleNode(CompositeTasksNode):
         :param raw_object:
         """
         super().__init__(
-            node_name, node_id or generate_id("role_"), raw_object=raw_object
+            node_name, node_id or generate_id("role_"), when=when, raw_object=raw_object
         )
         self.include_role = include_role
         if raw_object and not include_role:
             # If it's not an include_role, we take the role path which the path to the folder where the role is located
             # on the disk
             self.path = raw_object._role_path
-
-
-def _get_all_tasks_nodes(composite: CompositeNode, task_acc: List[TaskNode]):
-    """
-    :param composite:
-    :param task_acc:
-    :return:
-    """
-    items = composite.items()
-    for _, nodes in items:
-        for node in nodes:
-            if isinstance(node, TaskNode):
-                task_acc.append(node)
-            elif isinstance(node, CompositeNode):
-                _get_all_tasks_nodes(node, task_acc)
-
-
-def get_all_tasks_nodes(composite: CompositeNode) -> List[TaskNode]:
-    """
-    Return all the TaskNode inside a composite node
-    :param composite:
-    :return:
-    """
-    tasks: List[TaskNode] = []
-    _get_all_tasks_nodes(composite, tasks)
-    return tasks

--- a/ansibleplaybookgrapher/graph.py
+++ b/ansibleplaybookgrapher/graph.py
@@ -132,17 +132,17 @@ class CompositeNode(Node):
                 elif isinstance(node, CompositeNode):
                     node._get_all_tasks_nodes(task_acc)
 
-    def links_structure(self) -> Dict[Node, List[Node]]:
+    def links_structure(self) -> Dict[str, List[Node]]:
         """
         Return a representation of the composite node where each key of the dictionary is the node and the value is the
         list of the linked nodes
         :return:
         """
-        links: Dict[Node, List[Node]] = defaultdict(list)
+        links: Dict[str, List[Node]] = defaultdict(list)
         self._get_all_links(links)
         return links
 
-    def _get_all_links(self, links: Dict[Node, List[Node]]):
+    def _get_all_links(self, links: Dict[str, List[Node]]):
         """
         Recursively get the node links
         :return:
@@ -151,7 +151,7 @@ class CompositeNode(Node):
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     node._get_all_links(links)
-                links[self].append(node)
+                links[self.id].append(node)
 
 
 class CompositeTasksNode(CompositeNode):
@@ -278,51 +278,6 @@ class BlockNode(CompositeTasksNode):
             when=when,
             raw_object=raw_object,
         )
-
-
-class EdgeNode(CompositeNode):
-    """
-    An edge between two nodes. It's a special case of composite node with only one composition with one element
-    """
-
-    def __init__(
-        self, source: Node, destination: Node, node_name: str = "", node_id: str = None
-    ):
-        """
-
-        :param node_name: The edge name
-        :param source: The edge source node
-        :param destination: The edge destination node
-        :param node_id: The edge id
-        """
-        super().__init__(
-            node_name,
-            node_id or generate_id("edge_"),
-            raw_object=None,
-            supported_compositions=["destination"],
-        )
-        self.source = source
-        self.add_node("destination", destination)
-
-    def add_node(self, target_composition: str, node: Node):
-        """
-        Override the add_node. An edge node should only have one linked node
-        :param target_composition:
-        :param node:
-        :return:
-        """
-        current_nodes = self._compositions[target_composition]
-        if len(current_nodes) == 1:
-            raise Exception("An EdgeNode should have at most one linked node")
-        return super().add_node(target_composition, node)
-
-    @property
-    def destination(self) -> Node:
-        """
-        Return the destination of the edge
-        :return:
-        """
-        return self._compositions["destination"][0]
 
 
 class TaskNode(Node):

--- a/ansibleplaybookgrapher/graph.py
+++ b/ansibleplaybookgrapher/graph.py
@@ -134,8 +134,8 @@ class CompositeNode(Node):
 
     def links_structure(self) -> Dict[str, List[Node]]:
         """
-        Return a representation of the composite node where each key of the dictionary is the node and the value is the
-        list of the linked nodes
+        Return a representation of the composite node where each key of the dictionary is the node id and the
+         value is the list of the linked nodes
         :return:
         """
         links: Dict[str, List[Node]] = defaultdict(list)
@@ -147,7 +147,7 @@ class CompositeNode(Node):
         Recursively get the node links
         :return:
         """
-        for target, nodes in self._compositions.items():
+        for _, nodes in self._compositions.items():
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     node._get_all_links(links)

--- a/ansibleplaybookgrapher/graph.py
+++ b/ansibleplaybookgrapher/graph.py
@@ -120,7 +120,7 @@ class CompositeNode(Node):
 
     def _get_all_tasks_nodes(self, task_acc: List["Node"]):
         """
-
+        Recursively get all tasks
         :param task_acc:
         :return:
         """
@@ -282,7 +282,7 @@ class BlockNode(CompositeTasksNode):
 
 class TaskNode(Node):
     """
-    A task node. Can be pre_task, task or post_task
+    A task node. This matches an Ansible Task.
     """
 
     def __init__(
@@ -318,11 +318,19 @@ class RoleNode(CompositeTasksNode):
         :param node_id:
         :param raw_object:
         """
+        self.include_role = include_role
         super().__init__(
             node_name, node_id or generate_id("role_"), when=when, raw_object=raw_object
         )
-        self.include_role = include_role
-        if raw_object and not include_role:
+
+    def retrieve_position(self):
+        """
+        Retrieve the position depending on whether it's an include_role or not
+        :return:
+        """
+        if self.raw_object and not self.include_role:
             # If it's not an include_role, we take the role path which the path to the folder where the role is located
             # on the disk
-            self.path = raw_object._role_path
+            self.path = self.raw_object._role_path
+        else:
+            super().retrieve_position()

--- a/ansibleplaybookgrapher/postprocessor.py
+++ b/ansibleplaybookgrapher/postprocessor.py
@@ -128,10 +128,10 @@ class GraphVizPostProcessor:
         Insert graph in the SVG
         """
         links_structure = graph_representation.links_structure()
-        for node, node_links in links_structure.items():
+        for node_id, node_links in links_structure.items():
             # Find the group g with the specified id
             xpath_result = self.root.xpath(
-                f"ns:g/*[@id='{node.id}']", namespaces={"ns": SVG_NAMESPACE}
+                f"ns:g/*[@id='{node_id}']", namespaces={"ns": SVG_NAMESPACE}
             )
             if xpath_result:
                 element = xpath_result[0]

--- a/ansibleplaybookgrapher/renderer.py
+++ b/ansibleplaybookgrapher/renderer.py
@@ -373,9 +373,9 @@ class GraphvizRenderer:
                         source=play,
                         destination=post_task,
                         counter=len(play.pre_tasks)
-                                + len(play.roles)
-                                + len(play.tasks)
-                                + post_task_counter,
+                        + len(play.roles)
+                        + len(play.tasks)
+                        + post_task_counter,
                         color=color,
                         node_label_prefix="[post_task] ",
                     )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,7 +4,6 @@ from ansibleplaybookgrapher.graph import (
     EdgeNode,
     PlayNode,
     BlockNode,
-    get_all_tasks_nodes,
 )
 
 
@@ -56,13 +55,11 @@ def test_get_all_tasks_nodes():
     play = PlayNode("play")
 
     role_1 = RoleNode("my_role_1")
-    edge_role = EdgeNode(play, role_1, "from play to role")
-    play.add_node("roles", edge_role)
+    play.add_node("roles", role_1)
 
     # play -> role 1 -> edge 1 -> task 1
     task_1 = TaskNode("task 1")
-    edge_1 = EdgeNode(role_1, task_1, "from role1 to task 1")
-    role_1.add_node("tasks", edge_1)
+    role_1.add_node("tasks", task_1)
 
     # play -> block_1 -> task 2 and task 3
     block_1 = BlockNode("block 1")
@@ -77,6 +74,6 @@ def test_get_all_tasks_nodes():
     block_2.add_node("tasks", task_4)
     block_1.add_node("tasks", block_2)
 
-    all_tasks = get_all_tasks_nodes(play)
+    all_tasks = play.get_all_tasks()
     assert len(all_tasks) == 4, "There should be 4 tasks in all"
     assert [task_1, task_2, task_3, task_4] == all_tasks

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,6 @@
 from ansibleplaybookgrapher.graph import (
     RoleNode,
     TaskNode,
-    EdgeNode,
     PlayNode,
     BlockNode,
 )
@@ -14,37 +13,28 @@ def test_links_structure():
     """
     play = PlayNode("composite_node")
 
+    # play -> role -> task 1 and 2
     role = RoleNode("my_role_1")
-    edge_role = EdgeNode(play, role, "from play to role")
-    play.add_node("roles", edge_role)
-    # play -> role -> edge 1 -> task 1
+    play.add_node("roles", role)
     task_1 = TaskNode("task 1")
-    edge_1 = EdgeNode(role, task_1, "from role1 to task 1")
-    role.add_node("tasks", edge_1)
-
-    # play -> role -> edge 2 -> task 2
+    role.add_node("tasks", task_1)
     task_2 = TaskNode("task 2")
-    edge_2 = EdgeNode(role, task_2, "from role1 to task 2")
-    role.add_node("tasks", edge_2)
+    role.add_node("tasks", task_2)
 
-    # play -> edge 3 -> task 3
+    # play -> task 3
     task_3 = TaskNode("task 3")
-    edge_3 = EdgeNode(play, task_3, "from play to task 3")
-    play.add_node("tasks", edge_3)
+    play.add_node("tasks", task_3)
 
     all_links = play.links_structure()
-    assert len(all_links) == 6, "The links should contains only 6 elements"
+    assert len(all_links) == 2, "The links should contains only 6 elements"
 
-    assert len(all_links[play]) == 2, "The play should be linked to 2 nodes"
-    for e in [edge_role, edge_3]:
-        assert e in all_links[play], f"The play should be linked to the edge {e}"
+    assert len(all_links[play.id]) == 2, "The play should be linked to 2 nodes"
+    for e in [role, task_3]:
+        assert e in all_links[play.id], f"The play should be linked to the task {task_1}"
 
-    assert len(all_links[role]) == 2, "The role should be linked to two nodes"
-    for e in [edge_1, edge_2]:
-        assert e in all_links[role], f"The role should be linked to the edge {e}"
-
-    for e in [edge_1, edge_2, edge_3, edge_role]:
-        assert len(all_links[e]) == 1, "An edge should be linked to one node"
+    assert len(all_links[role.id]) == 2, "The role should be linked to two nodes"
+    for e in [task_1, task_2]:
+        assert e in all_links[role.id], f"The role should be linked to the edge {e}"
 
 
 def test_get_all_tasks_nodes():

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -30,7 +30,9 @@ def test_links_structure():
 
     assert len(all_links[play.id]) == 2, "The play should be linked to 2 nodes"
     for e in [role, task_3]:
-        assert e in all_links[play.id], f"The play should be linked to the task {task_1}"
+        assert (
+            e in all_links[play.id]
+        ), f"The play should be linked to the task {task_1}"
 
     assert len(all_links[role.id]) == 2, "The role should be linked to two nodes"
     for e in [task_1, task_2]:

--- a/tests/test_playbook_grapher.py
+++ b/tests/test_playbook_grapher.py
@@ -172,7 +172,7 @@ def test_include_tasks(request):
 
 def test_import_tasks(request):
     """
-    Test include_tasks.yml, an example with some imported tasks
+    Test import_tasks.yml, an example with some imported tasks
     """
     svg_path, playbook_path = run_grapher(
         "import_tasks.yml", output_filename=request.node.name


### PR DESCRIPTION
The EdgeNode is not really needed. The information it contains is owned by the destination node.

This is an internal change that should not impact the rendered graph.