### PR TITLE
fix: Render a single node when multiple playbooks use the same role

### DIFF
--- a/ansibleplaybookgrapher/__init__.py
+++ b/ansibleplaybookgrapher/__init__.py
@@ -17,5 +17,5 @@ from .parser import PlaybookParser
 from .postprocessor import GraphVizPostProcessor
 from .renderer import GraphvizRenderer
 
-__version__ = "1.1.2"
+__version__ = "1.1.3-dev"
 __prog__ = "ansible-playbook-grapher"

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -22,12 +22,14 @@ let currentSelectedElement = null;
 function highlightLinkedNodes(parentElement) {
     const parentElementId = $(parentElement).attr('id')
     $(parentElement).find('link').each(function (index, element) {
-        let target = $(element).attr('target');
-        let currentElement = $('#' + target);
+        const target = $(element).attr('target');
+        const edge = $(element).attr('edge');
+
+        const currentElement = $(`#${target}`);
         currentElement.addClass(HIGHLIGHT_CLASS);
 
         // Highlight the edge point to the target
-        $(`#edge_${parentElementId}_${target}`).addClass(HIGHLIGHT_CLASS);
+        $(`#${edge}`).addClass(HIGHLIGHT_CLASS);
 
         // Recursively highlight
         highlightLinkedNodes(currentElement);
@@ -48,14 +50,16 @@ function unHighlightLinkedNodes(parentElement, isHover) {
     if ($(parentElement).attr('id') !== currentSelectedElementId || !isHover) {
 
         $(parentElement).find('link').each(function (index, element) {
-            let linkedElementId = $(element).attr('target');
-            let linkedElement = $('#' + linkedElementId);
+            const linkedElementId = $(element).attr('target');
+            const edge = $(element).attr('edge');
+
+            const linkedElement = $('#' + linkedElementId);
 
             if (linkedElement.attr('id') !== currentSelectedElementId) {
                 linkedElement.removeClass(HIGHLIGHT_CLASS);
 
                 // Unhighlight the edge point to the target
-                $(`#edge_${parentElementId}_${linkedElementId}`).removeClass(HIGHLIGHT_CLASS);
+                $(`#${edge}`).removeClass(HIGHLIGHT_CLASS);
 
                 // Recursively unhighlight
                 unHighlightLinkedNodes(linkedElement, isHover);

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -17,16 +17,17 @@ let currentSelectedElement = null;
 
 /**
  * Highlight the linked nodes of the given root element
- * @param rootElement
+ * @param {Element} parentElement
  */
-function highlightLinkedNodes(rootElement) {
-    $(rootElement).find('link').each(function (index, element) {
+function highlightLinkedNodes(parentElement) {
+    const parentElementId = $(parentElement).attr('id')
+    $(parentElement).find('link').each(function (index, element) {
         let target = $(element).attr('target');
         let currentElement = $('#' + target);
         currentElement.addClass(HIGHLIGHT_CLASS);
 
         // Highlight the edge point to the target
-        $('#edge_' + target).addClass(HIGHLIGHT_CLASS);
+        $(`#edge_${parentElementId}_${target}`).addClass(HIGHLIGHT_CLASS);
 
         // Recursively highlight
         highlightLinkedNodes(currentElement);
@@ -36,24 +37,26 @@ function highlightLinkedNodes(rootElement) {
 
 /**
  * Unhighlight the linked nodes of the given root element
- * @param {Element} rootElement
+ * @param {Element} parentElement
  * @param {boolean} isHover True when we are coming from a mouseleave event. In that case, we should not unhighlight if
- * the rootElement is the current selected element
+ * the parentElement is the current selected element
  */
-function unHighlightLinkedNodes(rootElement, isHover) {
+function unHighlightLinkedNodes(parentElement, isHover) {
     const currentSelectedElementId = $(currentSelectedElement).attr('id');
-
+    const parentElementId = $(parentElement).attr('id')
     // Do not unhighlight the current current selected element
-    if ($(rootElement).attr('id') !== currentSelectedElementId || !isHover) {
+    if ($(parentElement).attr('id') !== currentSelectedElementId || !isHover) {
 
-        $(rootElement).find('link').each(function (index, element) {
+        $(parentElement).find('link').each(function (index, element) {
             let linkedElementId = $(element).attr('target');
             let linkedElement = $('#' + linkedElementId);
 
             if (linkedElement.attr('id') !== currentSelectedElementId) {
                 linkedElement.removeClass(HIGHLIGHT_CLASS);
+
                 // Unhighlight the edge point to the target
-                $('#edge_' + linkedElementId).removeClass(HIGHLIGHT_CLASS);
+                $(`#edge_${parentElementId}_${linkedElementId}`).removeClass(HIGHLIGHT_CLASS);
+
                 // Recursively unhighlight
                 unHighlightLinkedNodes(linkedElement, isHover);
             }

--- a/ansibleplaybookgrapher/graph.py
+++ b/ansibleplaybookgrapher/graph.py
@@ -14,7 +14,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import os
 from collections import defaultdict
-from typing import Dict, List, ItemsView
+from typing import Dict, List, ItemsView, Set
+from collections import defaultdict
 
 from ansibleplaybookgrapher.utils import generate_id
 
@@ -49,14 +50,14 @@ class Node:
         if self.raw_object and self.raw_object.get_ds():
             self.path, self.line, self.column = self.raw_object.get_ds().ansible_pos
 
-    def __str__(self):
-        return f"{type(self).__name__}(name='{self.name}')"
-
     def __repr__(self):
-        return f"{type(self).__name__}(id='{self.id}',name='{self.name}')"
+        return f"{type(self).__name__}(name='{self.name}',id='{self.id}')"
 
     def __eq__(self, other):
         return self.id == other.id
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def __hash__(self):
         return hash(self.id)
@@ -214,6 +215,20 @@ class PlaybookNode(CompositeNode):
         :return:
         """
         return self._compositions["plays"]
+
+    def roles_usage(self) -> Dict["RoleNode", Set[str]]:
+        """
+        For each role in the graph, return the plays that reference the role
+        :return: A dict with key as role ID and value the list of plays
+        """
+        usages = defaultdict(set)
+        links = self.links_structure()
+
+        for node_id, linked_nodes in links.items():
+            for linked_node in linked_nodes:
+                if isinstance(linked_node, RoleNode):
+                    usages[linked_node].add(node_id)
+        return usages
 
 
 class PlayNode(CompositeNode):

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -40,7 +40,8 @@ from ansibleplaybookgrapher.utils import (
     handle_include_path,
     has_role_parent,
     generate_id,
-    convert_when_to_str, hash_value,
+    convert_when_to_str,
+    hash_value,
 )
 
 display = Display()
@@ -224,8 +225,11 @@ class PlaybookParser(BaseParser):
                     # Go to the next role
                     continue
 
-                role_node = RoleNode(clean_name(role.get_name()), node_id="role_" + hash_value(role.get_name()),
-                                     raw_object=role)
+                role_node = RoleNode(
+                    clean_name(role.get_name()),
+                    node_id="role_" + hash_value(role.get_name()),
+                    raw_object=role,
+                )
                 # edge from play to role
                 play_node.add_node("roles", role_node)
 

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -40,7 +40,7 @@ from ansibleplaybookgrapher.utils import (
     handle_include_path,
     has_role_parent,
     generate_id,
-    convert_when_to_str,
+    convert_when_to_str, hash_value,
 )
 
 display = Display()
@@ -224,7 +224,8 @@ class PlaybookParser(BaseParser):
                     # Go to the next role
                     continue
 
-                role_node = RoleNode(clean_name(role.get_name()), raw_object=role)
+                role_node = RoleNode(clean_name(role.get_name()), node_id="role_" + hash_value(role.get_name()),
+                                     raw_object=role)
                 # edge from play to role
                 play_node.add_node("roles", role_node)
 
@@ -337,6 +338,7 @@ class PlaybookParser(BaseParser):
 
                     role_node = RoleNode(
                         task_or_block.get_name(),
+                        node_id="role_" + hash_value(task_or_block.get_name()),
                         when=convert_when_to_str(task_or_block.when),
                         raw_object=task_or_block,
                         include_role=True,

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -243,7 +243,7 @@ class PlaybookParser(BaseParser):
                             play_vars=play_vars,
                             node_type="task",
                         )
-                # end of roles loop
+                    # end of roles loop
 
             # loop through the tasks
             display.v("Parsing tasks...")
@@ -340,9 +340,11 @@ class PlaybookParser(BaseParser):
                         f"An 'include_role' found. Including tasks from '{task_or_block.get_name()}'"
                     )
 
+                    # Here we are using the role name instead of the task name to keep the same behavior  as a
+                    #  traditional role
                     role_node = RoleNode(
-                        task_or_block.get_name(),
-                        node_id="role_" + hash_value(task_or_block.get_name()),
+                        task_or_block._role_name,
+                        node_id="role_" + hash_value(task_or_block._role_name),
                         when=convert_when_to_str(task_or_block.when),
                         raw_object=task_or_block,
                         include_role=True,

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -336,9 +336,7 @@ class PlaybookParser(BaseParser):
                     # Here we have an 'include_role'. The class IncludeRole is a subclass of TaskInclude.
                     # We do this because the management of an 'include_role' is different.
                     # See :func:`~ansible.playbook.included_file.IncludedFile.process_include_results` from line 155
-                    display.v(
-                        f"An 'include_role' found. Including tasks from '{task_or_block.get_name()}'"
-                    )
+                    display.v(f"An 'include_role' found: '{task_or_block.get_name()}'")
 
                     # Here we are using the role name instead of the task name to keep the same behavior  as a
                     #  traditional role

--- a/ansibleplaybookgrapher/postprocessor.py
+++ b/ansibleplaybookgrapher/postprocessor.py
@@ -169,6 +169,7 @@ class GraphVizPostProcessor:
 
             # Move a little the text
             text_element.set("dy", "-0.5%")
+            text_element.set("dx", "2%")
             # Remove unnecessary attributes
             text_element.attrib.pop("x")
             text_element.attrib.pop("y")

--- a/ansibleplaybookgrapher/postprocessor.py
+++ b/ansibleplaybookgrapher/postprocessor.py
@@ -136,9 +136,15 @@ class GraphVizPostProcessor:
             if xpath_result:
                 element = xpath_result[0]
                 root_subelement = etree.Element("links")
-                for link in node_links:
+                for counter, link in enumerate(node_links, 1):
                     root_subelement.append(
-                        etree.Element("link", attrib={"target": link.id})
+                        etree.Element(
+                            "link",
+                            attrib={
+                                "target": link.id,
+                                "edge": f"edge_{counter}_{node_id}_{link.id}",
+                            },
+                        )
                     )
 
                 element.append(root_subelement)

--- a/ansibleplaybookgrapher/postprocessor.py
+++ b/ansibleplaybookgrapher/postprocessor.py
@@ -168,14 +168,19 @@ class GraphVizPostProcessor:
             # Create a curved textPath
             text_path = etree.Element("textPath")
             text_path.set("{http://www.w3.org/1999/xlink}href", f"#{path_id}")
-            text_path.set("text-anchor", "middle")
-            text_path.set("startOffset", "50%")
+
+            # Depending on the text length, put the edge label near the node
+            if len(text_element.text) < 5:
+                # This is when the edge is only the counter (no when condition)
+                text_path.set("startOffset", "75%")
+            else:
+                text_path.set("startOffset", "50%")
+
             text_path.text = text_element.text
             text_element.append(text_path)
 
             # Move a little the text
-            text_element.set("dy", "-0.5%")
-            text_element.set("dx", "2%")
+            text_element.set("dy", "-0.4%")
             # Remove unnecessary attributes
             text_element.attrib.pop("x")
             text_element.attrib.pop("y")

--- a/ansibleplaybookgrapher/postprocessor.py
+++ b/ansibleplaybookgrapher/postprocessor.py
@@ -168,19 +168,13 @@ class GraphVizPostProcessor:
             # Create a curved textPath
             text_path = etree.Element("textPath")
             text_path.set("{http://www.w3.org/1999/xlink}href", f"#{path_id}")
-
-            # Depending on the text length, put the edge label near the node
-            if len(text_element.text) < 5:
-                # This is when the edge is only the counter (no when condition)
-                text_path.set("startOffset", "75%")
-            else:
-                text_path.set("startOffset", "50%")
-
+            text_path.set("text-anchor", "middle")
+            text_path.set("startOffset", "50%")
             text_path.text = text_element.text
             text_element.append(text_path)
 
             # Move a little the text
-            text_element.set("dy", "-0.4%")
+            text_element.set("dy", "-0.5%")
             # Remove unnecessary attributes
             text_element.attrib.pop("x")
             text_element.attrib.pop("y")

--- a/ansibleplaybookgrapher/renderer.py
+++ b/ansibleplaybookgrapher/renderer.py
@@ -168,7 +168,7 @@ class GraphvizRenderer:
                 label=edge_label,
                 color=color,
                 fontcolor=color,
-                id=f"edge_${counter}_{source.id}_{destination.id}",
+                id=f"edge_{counter}_{source.id}_{destination.id}",
                 tooltip=edge_label,
                 labeltooltip=edge_label,
             )

--- a/ansibleplaybookgrapher/renderer.py
+++ b/ansibleplaybookgrapher/renderer.py
@@ -166,7 +166,7 @@ class GraphvizRenderer:
                 label=edge_label,
                 color=color,
                 fontcolor=color,
-                id=f"edge_{destination.id}",
+                id=f"edge_{source.id}_{destination.id}",
                 tooltip=edge_label,
                 labeltooltip=edge_label,
             )
@@ -201,7 +201,7 @@ class GraphvizRenderer:
             color=color,
             fontcolor=color,
             tooltip=edge_label,
-            id=f"edge_{destination.id}",
+            id=f"edge_{source.id}_{destination.id}",
             labeltooltip=edge_label,
         )
 
@@ -263,7 +263,7 @@ class GraphvizRenderer:
             label=role_edge_label,
             color=color,
             fontcolor=color,
-            id=f"edge_{destination.id}",
+            id=f"edge_{source.id}_{destination.id}",
             tooltip=role_edge_label,
             labeltooltip=role_edge_label,
         )
@@ -326,7 +326,7 @@ class GraphvizRenderer:
                 self.digraph.edge(
                     self.playbook_node.name,
                     play.id,
-                    id=f"edge_{play.id}",
+                    id=f"edge_{self.playbook_node.id}_{play.id}",
                     label=playbook_to_play_label,
                     color=color,
                     fontcolor=color,

--- a/ansibleplaybookgrapher/renderer.py
+++ b/ansibleplaybookgrapher/renderer.py
@@ -305,9 +305,7 @@ class GraphvizRenderer:
                     id=destination.id,
                     label=f"[role] {destination.name}",
                     tooltip=destination.name,
-                    color=role_color,
-                    fontcolor="white",
-                    style="filled",
+                    color=color,
                     URL=url,
                 )
                 # role tasks

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -12,6 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import hashlib
 import os
 import uuid
 from typing import Tuple, List
@@ -41,6 +42,22 @@ def convert_when_to_str(when: List) -> str:
     # Convert each element in the list to str
     when_to_str = list(map(str, when))
     return f"[when: {' and '.join(when_to_str)}]"
+
+
+def hash_value(value: str) -> str:
+    """
+    Convert name to md5 to avoid issues with special chars,
+    The ID are not visible to end user in web/rendered graph so we do
+    not have to care to make them look pretty.
+    There are chances for hash collisions, but we do not care for that
+    so much in here.
+    :param value: string which represents id
+    :return: string representing a hex hash
+    """
+
+    m = hashlib.md5()
+    m.update(value.encode('utf-8'))
+    return m.hexdigest()[:8]
 
 
 def generate_id(prefix: str = "") -> str:

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -56,7 +56,7 @@ def hash_value(value: str) -> str:
     """
 
     m = hashlib.md5()
-    m.update(value.encode('utf-8'))
+    m.update(value.encode("utf-8"))
     return m.hexdigest()[:8]
 
 

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -81,13 +81,13 @@ def clean_name(name: str):
     return name.strip().replace('"', "&#34;")
 
 
-def get_play_colors(play: object) -> Tuple[str, str]:
+def get_play_colors(play_id: str) -> Tuple[str, str]:
     """
     Generate two colors (in hex) for a given play: the main color and the color to use as a font color
-    :param play
+    :param play_id
     :return:
     """
-    picked_color = Color(pick_for=play, luminance=0.4)
+    picked_color = Color(pick_for=play_id, luminance=0.4)
     play_font_color = "#ffffff"
 
     return picked_color.get_hex_l(), play_font_color

--- a/tests/fixtures/include_role.yml
+++ b/tests/fixtures/include_role.yml
@@ -2,6 +2,9 @@
 - hosts: all
   tags:
     - play2
+  roles:
+    - fake_role
+    - display_some_facts
   tasks:
     - name: (0) First Include role (with loop)
       include_role:

--- a/tests/fixtures/multi-plays.yml
+++ b/tests/fixtures/multi-plays.yml
@@ -1,0 +1,42 @@
+---
+- hosts: all
+  pre_tasks:
+    - name: Pretask
+      debug: msg="Pretask"
+    - name: Pretask 2
+      debug: msg="Pretask"
+      tags:
+        - pre_task_tags
+  post_tasks:
+    - name: Posttask
+      debug: msg="Postask"
+    - name: Posttask 2
+      debug: msg="Postask"
+  roles:
+    - role: fake_role
+      when: ansible_distribution == "Debian"
+      tags:
+        - role_tag
+    - role: display_some_facts
+  tasks:
+    - name: Add backport {{backport}}
+      apt_repository:
+        filename: "{{backport}}"
+        state: present
+    - name: Install packages
+      apt:
+        name: "{{packages}}"
+        state: latest
+
+- hosts: database
+  roles:
+    - role: fake_role
+      when: ansible_distribution == "Debian"
+      tags:
+        - role_tag
+    - role: display_some_facts
+
+- hosts: webserver
+  roles:
+    - role: nested_include_role
+    - role: display_some_facts

--- a/tests/fixtures/roles/nested_include_role/tasks/main.yml
+++ b/tests/fixtures/roles/nested_include_role/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Ensure postgresql is at the latest version
+  ansible.builtin.yum:
+    name: postgresql
+    state: latest
+
+- name: Ensure that postgresql is started
+  ansible.builtin.service:
+    name: postgresql
+    state: started
+
+- name: Include role
+  when: x is not defined
+  include_role:
+    name: display_some_facts
+
+- name: Include role
+  include_role:
+    name: fake_role

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -221,11 +221,15 @@ def test_roles_usage(grapher_cli: PlaybookGrapherCLI):
     parser = PlaybookParser(
         grapher_cli.options.playbook_filename, include_role_tasks=True
     )
-    playbook = parser.parse()
-    roles_usage = playbook.roles_usage()
+    playbook_node = parser.parse()
+    roles_usage = playbook_node.roles_usage()
 
     for role, plays in roles_usage.items():
+        assert all(
+            map(lambda node_id: node_id.startswith("play_"), plays)
+        ), "All nodes IDs should be play"
         nb_plays = len(plays)
+
         if role.name == "fake_role":
             assert nb_plays == 3, "The role fake_role is used 3 times in the plays"
         elif role.name == "display_some_facts":

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,7 +113,7 @@ def test_include_role_parsing(grapher_cli: PlaybookGrapherCLI, capsys):
     assert isinstance(include_role_1, RoleNode)
     assert include_role_1.include_role
     assert include_role_1.path == os.path.join(FIXTURES_PATH, "include_role.yml")
-    assert include_role_1.line == 6
+    assert include_role_1.line == 9, "The first include role should be at line 9"
     assert (
         len(include_role_1.tasks) == 0
     ), "We don't support adding tasks from include_role with loop"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -227,8 +227,10 @@ def test_roles_usage(grapher_cli: PlaybookGrapherCLI):
     for role, plays in roles_usage.items():
         nb_plays = len(plays)
         if role.name == "fake_role":
-            assert nb_plays == 3, "The role fake_role is used in 3 plays"
+            assert nb_plays == 3, "The role fake_role is used 3 times in the plays"
         elif role.name == "display_some_facts":
-            assert nb_plays == 4, "The role display_some_facts is used in 4 plays"
+            assert (
+                nb_plays == 4
+            ), "The role display_some_facts is used 4 times in the plays"
         elif role.name == "nested_included_role":
             assert nb_plays == 1, "The role nested_included_role is used in 1 play"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -210,3 +210,25 @@ def test_block_parsing(grapher_cli: PlaybookGrapherCLI):
 
     # Check the post task
     assert post_tasks[0].name == "Debug"
+
+
+@pytest.mark.parametrize("grapher_cli", [["multi-plays.yml"]], indirect=True)
+def test_roles_usage(grapher_cli: PlaybookGrapherCLI):
+    """
+
+    :return:
+    """
+    parser = PlaybookParser(
+        grapher_cli.options.playbook_filename, include_role_tasks=True
+    )
+    playbook = parser.parse()
+    roles_usage = playbook.roles_usage()
+
+    for role, plays in roles_usage.items():
+        nb_plays = len(plays)
+        if role.name == "fake_role":
+            assert nb_plays == 3, "The role fake_role is used in 3 plays"
+        elif role.name == "display_some_facts":
+            assert nb_plays == 4, "The role display_some_facts is used in 4 plays"
+        elif role.name == "nested_included_role":
+            assert nb_plays == 1, "The role nested_included_role is used in 1 play"

--- a/tests/test_playbook_grapher.py
+++ b/tests/test_playbook_grapher.py
@@ -230,7 +230,7 @@ def test_include_role(request, include_role_tasks_option, expected_tasks_number)
         playbook_path=playbook_path,
         plays_number=1,
         tasks_number=expected_tasks_number,
-        roles_number=4,
+        roles_number=3,
     )
 
 

--- a/tests/test_playbook_grapher.py
+++ b/tests/test_playbook_grapher.py
@@ -392,6 +392,27 @@ def test_skip_tags(request):
     )
 
 
+def test_multi_plays(request):
+    """
+    Test with multiple plays, include_role and roles
+    """
+
+    svg_path, playbook_path = run_grapher(
+        "multi-plays.yml",
+        output_filename=request.node.name,
+        additional_args=["--include-role-tasks"],
+    )
+    _common_tests(
+        svg_path=svg_path,
+        playbook_path=playbook_path,
+        plays_number=3,
+        roles_number=3,
+        pre_tasks_number=2,
+        tasks_number=10,
+        post_tasks_number=2,
+    )
+
+
 def test_with_roles_with_custom_protocol_handlers(request):
     """
     Test with_roles.yml with a custom protocol handlers


### PR DESCRIPTION
Related to #110 and some improvements:
- The role node style has been changed to filled. 
- When a role is used multiple times, its color is a combination of all the plays that use it. All the external edges are also a combination of these colors
![Capture d’écran 2022-06-26 à 23 16 36](https://user-images.githubusercontent.com/9849996/175834127-a86f46c7-9aa8-4ade-affa-b096e3e495dc.png)

