### PR TITLE
Forbid incompatible ansible-core versions >= 2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core>=2.11,<3
+ansible-core>=2.11,<2.13
 graphviz>=0.18,<1
 colour<1
 lxml<5


### PR DESCRIPTION
Fixes #113 by further constraining the ansible-core version. On the long run ansible-playbook-grapher should probably be made compatible with that version.