### PR TITLE
feat: Add initial support for handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ JavaScript:
   Lastly, you can provide your own protocol formats
   with `--open-protocol-handler custom --open-protocol-custom-formats '{}'`. See the help
   and [an example.](https://github.com/haidaraM/ansible-playbook-grapher/blob/34e0aef74b82808dceb6ccfbeb333c0b531eac12/ansibleplaybookgrapher/renderer/__init__.py#L32-L41)
+  To not confuse with [Ansible Handlers.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html)
 - Export the dot file used to generate the graph with Graphviz.
 
 ## Prerequisites
@@ -397,11 +398,14 @@ regarding the blocks.
 The available options:
 
 ```
-usage: ansible-playbook-grapher [-h] [-v] [-i INVENTORY] [--include-role-tasks] [-s] [--view] [-o OUTPUT_FILENAME]
-                                [--open-protocol-handler {default,vscode,custom}] [--open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS]
-                                [--group-roles-by-name] [--renderer {graphviz,mermaid-flowchart,json}] [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
-                                [--renderer-mermaid-orientation {TD,RL,BT,RL,LR}] [--version] [--hide-plays-without-roles] [--hide-empty-plays] [-t TAGS]
-                                [--skip-tags SKIP_TAGS] [--vault-id VAULT_IDS] [-J | --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
+usage: ansible-playbook-grapher [-h] [-v] [--exclude-roles EXCLUDE_ROLES] [--only-roles] [-i INVENTORY] [--include-role-tasks] [-s]
+                                [--view] [-o OUTPUT_FILENAME] [--open-protocol-handler {default,vscode,custom}]
+                                [--open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS] [--group-roles-by-name]
+                                [--renderer {graphviz,mermaid-flowchart,json}]
+                                [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
+                                [--renderer-mermaid-orientation {TD,RL,BT,RL,LR}] [--version] [--hide-plays-without-roles]
+                                [--hide-empty-plays] [--show-handlers] [-t TAGS] [--skip-tags SKIP_TAGS] [--vault-id VAULT_IDS] [-J |
+                                --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
                                 playbooks [playbooks ...]
 
 Make graphs from your Ansible Playbooks.
@@ -419,7 +423,7 @@ options:
                         Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as tasks are
                         considered (no import_role).
   --include-role-tasks  Include the tasks of the roles in the graph. Applied when parsing the playbooks.
-  --only-roles          Ignore all tasks when rendering graphs.
+  --only-roles          Only display the roles in the graph (ignoring the tasks)
   --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
                         The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to custom. You should provide a
                         JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to open folders (roles) inside the browser and files
@@ -438,12 +442,13 @@ options:
                         https://mermaid.js.org/config/directives.html. Default: '%%{ init: { "flowchart": { "curve": "bumpX" } } }%%'
   --renderer-mermaid-orientation {TD,RL,BT,RL,LR}
                         The orientation of the flow chart. Default: 'LR'
+  --show-handlers       Show the handlers in the graph. See the limitations in the project README on GitHub.
   --skip-tags SKIP_TAGS
                         only run plays and tasks whose tags do not match these values. This argument may be specified multiple times.
   --vault-id VAULT_IDS  the vault identity to use. This argument may be specified multiple times.
   --vault-password-file VAULT_PASSWORD_FILES, --vault-pass-file VAULT_PASSWORD_FILES
                         vault password file
-  --version
+  --version             show program's version number and exit
   --view                Automatically open the resulting SVG file with your system's default viewer application for the file type
   -J, --ask-vault-password, --ask-vault-pass
                         ask for vault password
@@ -481,6 +486,9 @@ More information [here](https://docs.ansible.com/ansible/latest/reference_append
   Always check the edge label to know the task order.
 - The label of the edges may overlap with each other. They are positioned so that they are as close as possible to
   the target nodes. If the same role is used in multiple plays or playbooks, the labels can overlap.
+- **Ansible Handlers**: The handlers are partially supported for the moment. Their position in the graph doesn't entirely
+  reflect their real order of execution in the playbook. They are displayed at the end of the play and roles, but they
+  might be executed before that.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ At the time of writing, two renderers are supported:
 2. `mermaid-flowchart`: Generate the graph in [Mermaid](https://mermaid.js.org/syntax/flowchart.html) format. You can
    directly embed the graph in your Markdown and GitHub (
    and [other integrations](https://mermaid.js.org/ecosystem/integrations.html)) will render it.
-3. `json`: Generate a JSON representation of the graph to be used by other tools. The corresponding JSON schema
-   is [here.](https://github.com/haidaraM/ansible-playbook-grapher/tree/main/tests/fixtures/json-schemas)
+3. `json`: Generate a JSON representation of the graph. The corresponding JSON schema
+   is [here.](https://github.com/haidaraM/ansible-playbook-grapher/tree/main/tests/fixtures/json-schemas) The JSON
+   output will give you more flexibility to create your own renderer.
 
 If you are interested to support more renderers, feel free to create an issue or raise a PR based on the existing
 renderers.

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -97,6 +97,7 @@ class PlaybookGrapherCLI(CLI):
                     save_dot_file=self.options.save_dot_file,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    show_handlers=self.options.show_handlers,
                 )
 
             case "mermaid-flowchart":
@@ -113,6 +114,7 @@ class PlaybookGrapherCLI(CLI):
                     orientation=self.options.renderer_mermaid_orientation,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    show_handlers=self.options.show_handlers,
                 )
 
             case "json":
@@ -124,6 +126,7 @@ class PlaybookGrapherCLI(CLI):
                     view=self.options.view,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    show_handlers=self.options.show_handlers,
                 )
 
             case _:
@@ -301,6 +304,14 @@ class PlaybookGrapherCLI(CLI):
             action="store_true",
             default=False,
             help="Hide the plays that end up with no tasks in the graph (after applying the tags filter).",
+        )
+
+        self.parser.add_argument(
+            "--show-handlers",
+            dest="show_handlers",
+            action="store_true",
+            default=False,
+            help="Show the handlers in the graph. See the limitations in the project README on GitHub.",
         )
 
         self.parser.add_argument(

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -368,7 +368,7 @@ class PlaybookGrapherCLI(CLI):
         if self.options.open_protocol_handler == "custom":
             self.validate_open_protocol_custom_formats()
 
-        # create list of roles to exclude
+        # create the list of roles to exclude
         if options.exclude_roles:
             exclude_roles = set()
             for arg in options.exclude_roles:
@@ -386,6 +386,13 @@ class PlaybookGrapherCLI(CLI):
                         exclude_roles.add(role.strip())
 
             options.exclude_roles = sorted(exclude_roles)
+
+        if self.options.show_handlers:
+            display.warning(
+                "The handlers are partially supported for the moment. Their position in the graph doesn't entirely reflect "
+                "their real order of execution in the playbook. They are displayed at the end of the play and roles, "
+                "but they might be executed before that."
+            )
 
         return options
 

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -87,6 +87,15 @@ class Node:
         """Return the display name of the node.
 
         It's composed of the ID prefix between brackets and the name of the node.
+        Examples:
+         - [playbook] My playbook
+         - [play] My play
+         - [pre_task] My pre task
+         - [role] My role
+         - [task] My task
+         - [block] My block
+         - [post_task] My post task
+
         :return:
         """
         try:

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -480,13 +480,6 @@ class PlayNode(CompositeNode):
     def tasks(self) -> list["Node"]:
         return self.get_nodes("tasks")
 
-    def clear_handlers(self) -> None:
-        """Remove the handlers from the play.
-
-        :return:
-        """
-        self._compositions["handlers"] = []
-
     @property
     def handlers(self) -> list["TaskNode"]:
         """Return the handlers defined at the play level.

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -579,7 +579,7 @@ class TaskNode(LoopMixin, Node):
 
         :return:
         """
-        return isinstance(self.raw_object, Handler)
+        return isinstance(self.raw_object, Handler) or self.id.startswith("handler_")
 
 
 class RoleNode(LoopMixin, CompositeNode):
@@ -620,7 +620,7 @@ class RoleNode(LoopMixin, CompositeNode):
         :return:
         """
         if target_composition != "handlers":
-            # If we are not adding a handler, we always add the node to the tasks composition
+            # If we are not adding a handler, we always add the node to the task composition
             super().add_node("tasks", node)
         else:
             super().add_node("handlers", node)

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -192,8 +192,6 @@ class CompositeNode(Node):
         self._supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition: plays, tasks, roles...
         self._compositions = defaultdict(list)  # type: dict[str, list]
-        # Used to count the number of nodes in this composite node
-        self._node_counter = 0
 
     def add_node(self, target_composition: str, node: Node) -> None:
         """Add a node in the target composition.
@@ -208,9 +206,21 @@ class CompositeNode(Node):
                 msg,
             )
         self._compositions[target_composition].append(node)
-        # The node index is position in the composition regardless of the type of the node
-        node.index = self._node_counter + 1
-        self._node_counter += 1
+
+    def calculate_indices(self):
+        """
+        Calculate the indices of all nodes based on their composition type.
+        This is only called when needed.
+        """
+        current_index = 1
+        for comp_type in self._supported_compositions:
+            for node in self._compositions[comp_type]:
+                node.index = current_index
+                current_index += 1
+
+                if isinstance(node, CompositeNode):
+                    node.calculate_indices()
+
 
     def get_nodes(self, target_composition: str) -> list:
         """Get a node from the compositions.

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -63,7 +63,6 @@ class Node:
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
     ) -> None:
         """:param node_name: The name of the node
         :param node_id: An identifier for this node
@@ -82,7 +81,7 @@ class Node:
         self.set_location()
 
         # The index of this node in the parent node if it has one (starting from 1)
-        self.index: int | None = index
+        self.index: int | None = None
 
     def set_location(self) -> None:
         """Set the location of this node based on the raw object. Not all objects have path.
@@ -173,7 +172,6 @@ class CompositeNode(Node):
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
         supported_compositions: list[str] | None = None,
     ) -> None:
         """Init a composite node.
@@ -190,7 +188,6 @@ class CompositeNode(Node):
             when=when,
             raw_object=raw_object,
             parent=parent,
-            index=index,
         )
         self._supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition: plays, tasks, roles...
@@ -332,14 +329,12 @@ class PlaybookNode(CompositeNode):
         node_id: str | None = None,
         when: str = "",
         raw_object: Any = None,
-        index: int | None = None,
     ) -> None:
         super().__init__(
             node_name=node_name,
             node_id=node_id or generate_id("playbook_"),
             when=when,
             raw_object=raw_object,
-            index=index,
             supported_compositions=["plays"],
         )
 
@@ -440,7 +435,6 @@ class PlayNode(CompositeNode):
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
         hosts: list[str] | None = None,
     ) -> None:
         """
@@ -455,7 +449,6 @@ class PlayNode(CompositeNode):
             when=when,
             raw_object=raw_object,
             parent=parent,
-            index=index,
             supported_compositions=[
                 "pre_tasks",
                 "roles",
@@ -486,6 +479,13 @@ class PlayNode(CompositeNode):
     @property
     def tasks(self) -> list["Node"]:
         return self.get_nodes("tasks")
+
+    def clear_handlers(self) -> None:
+        """Remove the handlers from the play.
+
+        :return:
+        """
+        self._compositions["handlers"] = []
 
     @property
     def handlers(self) -> list["TaskNode"]:
@@ -519,7 +519,6 @@ class BlockNode(CompositeNode):
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
     ) -> None:
         super().__init__(
             node_name=node_name,
@@ -528,7 +527,6 @@ class BlockNode(CompositeNode):
             raw_object=raw_object,
             parent=parent,
             supported_compositions=["tasks"],
-            index=index,
         )
 
     def add_node(self, target_composition: str, node: Node) -> None:
@@ -559,7 +557,6 @@ class TaskNode(LoopMixin, Node):
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
     ) -> None:
         """:param node_name:
         :param node_id:
@@ -571,7 +568,6 @@ class TaskNode(LoopMixin, Node):
             when=when,
             raw_object=raw_object,
             parent=parent,
-            index=index,
         )
 
     def is_handler(self) -> bool:
@@ -592,7 +588,6 @@ class RoleNode(LoopMixin, CompositeNode):
         when: str = "",
         raw_object: Any = None,
         parent: "Node" = None,
-        index: int | None = None,
         include_role: bool = False,
     ) -> None:
         """
@@ -609,7 +604,6 @@ class RoleNode(LoopMixin, CompositeNode):
             raw_object=raw_object,
             parent=parent,
             supported_compositions=["tasks", "handlers"],
-            index=index,
         )
 
     def add_node(self, target_composition: str, node: Node) -> None:

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -83,6 +83,19 @@ class Node:
         # The index of this node in the parent node if it has one (starting from 1)
         self.index: int | None = None
 
+    def display_name(self) -> str:
+        """Return the display name of the node.
+
+        It's composed of the ID prefix between brackets and the name of the node.
+        :return:
+        """
+        try:
+            split = self.id.split("_")
+            id_prefix = "_".join(split[:-1])
+            return f"[{id_prefix}] {self.name}"
+        except IndexError:
+            return self.name
+
     def set_location(self) -> None:
         """Set the location of this node based on the raw object. Not all objects have path.
 
@@ -220,7 +233,6 @@ class CompositeNode(Node):
 
                 if isinstance(node, CompositeNode):
                     node.calculate_indices()
-
 
     def get_nodes(self, target_composition: str) -> list:
         """Get a node from the compositions.
@@ -469,6 +481,13 @@ class PlayNode(CompositeNode):
         )
         self.hosts = hosts or []
         self.colors: tuple[str, str] = get_play_colors(self.id)
+
+    def display_name(self) -> str:
+        """
+        Return the display name of the node.
+        :return:
+        """
+        return f"Play: {self.name} ({len(self.hosts)})"
 
     @property
     def roles(self) -> list["RoleNode"]:

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -422,12 +422,14 @@ class PlaybookNode(CompositeNode):
         self,
         exclude_empty_plays: bool = False,
         exclude_plays_without_roles: bool = False,
+        include_handlers: bool = False,
         **kwargs,
     ) -> dict:
         """Return a dictionary representation of this playbook.
 
         :param exclude_empty_plays: Whether to exclude the empty plays from the result or not
         :param exclude_plays_without_roles: Whether to exclude the plays that do not have roles
+        :param include_handlers: Whether to include the handlers in the output or not
         :param kwargs:
         :return:
         """
@@ -439,7 +441,9 @@ class PlaybookNode(CompositeNode):
             exclude_empty=exclude_empty_plays,
             exclude_without_roles=exclude_plays_without_roles,
         ):
-            playbook_dict["plays"].append(play.to_dict(**kwargs))
+            playbook_dict["plays"].append(
+                play.to_dict(include_handlers=include_handlers, **kwargs)
+            )
 
         return playbook_dict
 
@@ -521,15 +525,19 @@ class PlayNode(CompositeNode):
         """
         return self.get_nodes("handlers")
 
-    def to_dict(self, **kwargs) -> dict:
+    def to_dict(self, include_handlers: bool = False, **kwargs) -> dict:
         """Return a dictionary representation of this composite node. This representation is not meant to get the
         original object back.
 
         :return:
         """
-        data = super().to_dict(**kwargs)
+
+        data = super().to_dict(include_handlers=include_handlers, **kwargs)
         data["hosts"] = self.hosts
         data["colors"] = {"main": self.colors[0], "font": self.colors[1]}
+
+        if not include_handlers:
+            data["handlers"] = []
 
         return data
 
@@ -664,15 +672,19 @@ class RoleNode(LoopMixin, CompositeNode):
 
         return super().has_loop()
 
-    def to_dict(self, **kwargs) -> dict:
+    def to_dict(self, include_handlers: bool = False, **kwargs) -> dict:
         """Return a dictionary representation of this composite node. This representation is not meant to get the
         original object back.
 
+        :param include_handlers: Whether to include the handlers in the output or not
         :param kwargs:
         :return:
         """
         node_dict = super().to_dict(**kwargs)
         node_dict["include_role"] = self.include_role
+
+        if not include_handlers:
+            node_dict["handlers"] = []
 
         return node_dict
 

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -360,6 +360,9 @@ class PlaybookNode(CompositeNode):
             supported_compositions=["plays"],
         )
 
+    def display_name(self) -> str:
+        return self.name
+
     def set_location(self) -> None:
         """Playbooks only have the path as position.
 

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -343,9 +343,9 @@ class PlaybookParser(BaseParser):
             display.v(f"{len(play_node.roles)} role(s) added to the play")
             display.v(f"{len(play_node.tasks)} task(s) added to the play")
             display.v(f"{len(play_node.post_tasks)} post_task(s) added to the play")
+            # moving to the next play
 
-        # moving to the next play
-
+        playbook_root_node.calculate_indices()
         return playbook_root_node
 
     def _include_tasks_in_blocks(

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -611,6 +611,3 @@ def _add_handlers_in_notify(play_node: PlayNode):
     _add_notified_handlers(play_node, "pre_tasks", play_node.pre_tasks)
     _add_notified_handlers(play_node, "tasks", play_node.tasks)
     _add_notified_handlers(play_node, "post_tasks", play_node.post_tasks)
-
-    # We clear the handlers from the play because they are already added in the graph
-    play_node.clear_handlers()

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -161,7 +161,7 @@ class PlaybookParser(BaseParser):
         :param group_roles_by_name: Group roles by name instead of considering them as separate nodes with different IDs.
         :param playbook_name: On optional name of the playbook to parse.
         :param exclude_roles: Only add tasks whose roles do not match these values
-        :param only_roles: Ignore all task nodes when rendering graph
+        :param only_roles: Ignore all task nodes when rendering the graph.
         It will be used as the node name if provided in replacement of the file name.
         """
         super().__init__(tags=tags, skip_tags=skip_tags)
@@ -214,8 +214,7 @@ class PlaybookParser(BaseParser):
                     self.template(play.hosts, play_vars),
                 )
             ]
-            play_name = f"Play: {clean_name(play.get_name())} ({len(play_hosts)})"
-            play_name = self.template(play_name, play_vars)
+            play_name = self.template(clean_name(play.get_name()), play_vars)
 
             display.v(f"Parsing {play_name}")
 

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -293,7 +293,7 @@ class PlaybookParser(BaseParser):
                             node_type="task",
                         )
 
-                    # loop through handlers of the roles
+                    # loop through the handlers of the roles
                     for block in role.get_handler_blocks(play):
                         self._include_tasks_in_blocks(
                             current_play=play,
@@ -336,7 +336,8 @@ class PlaybookParser(BaseParser):
                     node_type="handler",
                 )
 
-            _add_handlers_in_notify(play_node)
+            # TODO: Add handlers only only if they are notified AND after each section.
+            # add_handlers_in_notify(play_node)
             # Summary
             display.v(f"{len(play_node.pre_tasks)} pre_task(s) added to the graph.")
             display.v(f"{len(play_node.roles)} role(s) added to the play")
@@ -560,6 +561,23 @@ class PlaybookParser(BaseParser):
                 )
 
 
+def add_handlers_in_notify(play_node: PlayNode):
+    """
+    Add the handlers in the "notify" attribute of the tasks. This has to be done separately for the pre_tasks, tasks
+    and post_tasks because the handlers are not shared between them.
+
+    Handlers not used will not be kept in the graph.
+
+    The role handlers are managed separately.
+    :param play_node:
+    :return:
+    """
+
+    _add_notified_handlers(play_node, "pre_tasks", play_node.pre_tasks)
+    _add_notified_handlers(play_node, "tasks", play_node.tasks)
+    _add_notified_handlers(play_node, "post_tasks", play_node.post_tasks)
+
+
 def _add_notified_handlers(
     play_node: PlayNode, target_composition: str, tasks: list[Node]
 ) -> list[str]:
@@ -593,20 +611,3 @@ def _add_notified_handlers(
             )
 
     return notified_handlers
-
-
-def _add_handlers_in_notify(play_node: PlayNode):
-    """
-    Add the handlers in the "notify" attribute of the tasks. This has to be done separately for the pre_tasks, tasks
-    and post_tasks because the handlers are not shared between them.
-
-    Handlers not used will not be kept in the graph.
-
-    The role handlers are managed separately.
-    :param play_node:
-    :return:
-    """
-
-    _add_notified_handlers(play_node, "pre_tasks", play_node.pre_tasks)
-    _add_notified_handlers(play_node, "tasks", play_node.tasks)
-    _add_notified_handlers(play_node, "post_tasks", play_node.post_tasks)

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -123,7 +123,6 @@ class PlaybookBuilder(ABC):
                 task_node=node,
                 color=color,
                 fontcolor=fontcolor,
-                node_label_prefix=kwargs.pop("node_label_prefix", ""),
                 **kwargs,
             )
         else:
@@ -167,7 +166,6 @@ class PlaybookBuilder(ABC):
                 node=pre_task,
                 color=color,
                 fontcolor=play_font_color,
-                node_label_prefix="[pre_task] ",
                 **kwargs,
             )
 
@@ -185,7 +183,6 @@ class PlaybookBuilder(ABC):
                     node=r_handler,
                     color=color,
                     fontcolor=play_font_color,
-                    node_label_prefix="[handler] ",
                     **kwargs,
                 )
 
@@ -195,7 +192,6 @@ class PlaybookBuilder(ABC):
                 node=task,
                 color=color,
                 fontcolor=play_font_color,
-                node_label_prefix="[task] ",
                 **kwargs,
             )
 
@@ -205,7 +201,6 @@ class PlaybookBuilder(ABC):
                 node=post_task,
                 color=color,
                 fontcolor=play_font_color,
-                node_label_prefix="[post_task] ",
                 **kwargs,
             )
 

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -204,6 +204,16 @@ class PlaybookBuilder(ABC):
                 **kwargs,
             )
 
+        # play handlers
+        for p_handler in play_node.handlers:
+            self.build_node(
+                node=p_handler,
+                color=color,
+                fontcolor=play_font_color,
+                node_label_prefix="[handler] ",
+                **kwargs,
+            )
+
     @abstractmethod
     def build_task(
         self,

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -180,6 +180,15 @@ class PlaybookBuilder(ABC):
                 **kwargs,
             )
 
+            for r_handler in role.handlers:
+                self.build_node(
+                    node=r_handler,
+                    color=color,
+                    fontcolor=play_font_color,
+                    node_label_prefix="[handler] ",
+                    **kwargs,
+                )
+
         # tasks
         for task in play_node.tasks:
             self.build_node(
@@ -197,6 +206,16 @@ class PlaybookBuilder(ABC):
                 color=color,
                 fontcolor=play_font_color,
                 node_label_prefix="[post_task] ",
+                **kwargs,
+            )
+
+        # play handlers
+        for p_handler in play_node.handlers:
+            self.build_node(
+                node=p_handler,
+                color=color,
+                fontcolor=play_font_color,
+                node_label_prefix="[handler] ",
                 **kwargs,
             )
 

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -209,16 +209,6 @@ class PlaybookBuilder(ABC):
                 **kwargs,
             )
 
-        # play handlers
-        for p_handler in play_node.handlers:
-            self.build_node(
-                node=p_handler,
-                color=color,
-                fontcolor=play_font_color,
-                node_label_prefix="[handler] ",
-                **kwargs,
-            )
-
     @abstractmethod
     def build_task(
         self,

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -136,26 +136,35 @@ class PlaybookBuilder(ABC):
         self,
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
+        show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build the whole playbook
         :param hide_empty_plays: Whether to hide empty plays or not
-        :param hide_plays_without_roles:
+        :param hide_plays_without_roles: Whether to hide plays without roles or not
+        :param show_handlers: Whether to show the handlers or not.
         :param kwargs:
         :return: The rendered playbook as a string.
         """
 
     @abstractmethod
-    def build_play(self, play_node: PlayNode, **kwargs) -> None:
+    def build_play(
+        self, play_node: PlayNode, show_handlers: bool = False, **kwargs
+    ) -> None:
         """Build a single play to be rendered
-        :param play_node:
+
+        :param play_node: The play to render
+        :param show_handlers: Whether to show the handlers or not.
         :param kwargs:
         :return:
         """
 
-    def traverse_play(self, play_node: PlayNode, **kwargs) -> None:
+    def traverse_play(
+        self, play_node: PlayNode, show_handlers: bool = False, **kwargs
+    ) -> None:
         """Traverse a play to build the graph: pre_tasks, roles, tasks, post_tasks
         :param play_node:
+        :param show_handlers: Whether to show the handlers or not.
         :param kwargs:
         :return:
         """
@@ -178,13 +187,14 @@ class PlaybookBuilder(ABC):
                 **kwargs,
             )
 
-            for r_handler in role.handlers:
-                self.build_node(
-                    node=r_handler,
-                    color=color,
-                    fontcolor=play_font_color,
-                    **kwargs,
-                )
+            if show_handlers:
+                for r_handler in role.handlers:
+                    self.build_node(
+                        node=r_handler,
+                        color=color,
+                        fontcolor=play_font_color,
+                        **kwargs,
+                    )
 
         # tasks
         for task in play_node.tasks:
@@ -204,15 +214,16 @@ class PlaybookBuilder(ABC):
                 **kwargs,
             )
 
-        # play handlers
-        for p_handler in play_node.handlers:
-            self.build_node(
-                node=p_handler,
-                color=color,
-                fontcolor=play_font_color,
-                node_label_prefix="[handler] ",
-                **kwargs,
-            )
+        if show_handlers:
+            # play handlers
+            for p_handler in play_node.handlers:
+                self.build_node(
+                    node=p_handler,
+                    color=color,
+                    fontcolor=play_font_color,
+                    node_label_prefix="[handler] ",
+                    **kwargs,
+                )
 
     @abstractmethod
     def build_task(

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -88,7 +88,7 @@ class GraphvizRenderer(Renderer):
             builder.build_playbook(
                 hide_empty_plays=hide_empty_plays,
                 hide_plays_without_roles=hide_plays_without_roles,
-                show_handlers=show_handlers
+                show_handlers=show_handlers,
             )
             roles_built.update(builder.roles_built)
 

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -215,7 +215,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             # block node
             cluster_block_subgraph.node(
                 block_node.id,
-                label=f"{block_node.display_name()}",
+                label=block_node.display_name(),
                 shape="box",
                 style="filled",
                 id=block_node.id,
@@ -284,7 +284,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             role_subgraph.node(
                 role_node.id,
                 id=role_node.id,
-                label=f"{role_node.display_name()}",
+                label=role_node.display_name(),
                 style="filled",
                 tooltip=role_node.name,
                 fontcolor=fontcolor,

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -153,10 +153,17 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         node_label_prefix = kwargs["node_label_prefix"]
         edge_label = f"{task_node.index} {task_node.when}"
 
+        edge_style = "solid"
+        node_shape = "rectangle"
+
+        if task_node.is_handler():
+            edge_style = "dotted"
+            node_shape = "octagon"
+
         digraph.node(
             task_node.id,
             label=node_label_prefix + task_node.name,
-            shape="octagon",
+            shape=node_shape,
             id=task_node.id,
             tooltip=task_node.name,
             color=color,
@@ -173,6 +180,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             id=f"edge_{task_node.index}_{task_node.parent.id}_{task_node.id}",
             tooltip=edge_label,
             labeltooltip=edge_label,
+            style=edge_style,
         )
 
     def build_block(

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -155,10 +155,12 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
 
         edge_style = "solid"
         node_shape = "rectangle"
+        node_style = "solid"
 
         if task_node.is_handler():
             edge_style = "dotted"
-            node_shape = "octagon"
+            node_shape = "hexagon"
+            node_style = "dotted"
 
         digraph.node(
             task_node.id,
@@ -167,6 +169,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             id=task_node.id,
             tooltip=task_node.name,
             color=color,
+            style=node_style,
             URL=self.get_node_url(task_node),
         )
 

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -150,7 +150,6 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         """
         # Here we have a TaskNode
         digraph = kwargs["digraph"]
-        node_label_prefix = kwargs["node_label_prefix"]
         edge_label = f"{task_node.index} {task_node.when}"
 
         edge_style = "solid"
@@ -164,7 +163,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
 
         digraph.node(
             task_node.id,
-            label=node_label_prefix + task_node.name,
+            label=task_node.display_name(),
             shape=node_shape,
             id=task_node.id,
             tooltip=task_node.name,
@@ -216,7 +215,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             # block node
             cluster_block_subgraph.node(
                 block_node.id,
-                label=f"[block] {block_node.name}",
+                label=f"{block_node.display_name()}",
                 shape="box",
                 style="filled",
                 id=block_node.id,
@@ -285,7 +284,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             role_subgraph.node(
                 role_node.id,
                 id=role_node.id,
-                label=f"[role] {role_node.name}",
+                label=f"{role_node.display_name()}",
                 style="filled",
                 tooltip=role_node.name,
                 fontcolor=fontcolor,
@@ -347,7 +346,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         digraph.node(
             play_node.id,
             id=play_node.id,
-            label=play_node.name,
+            label=play_node.display_name(),
             style="filled",
             shape="box",
             color=color,
@@ -357,7 +356,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         )
 
         # from playbook to play
-        playbook_to_play_label = f"{play_node.index} {play_node.name}"
+        playbook_to_play_label = f"{play_node.index}"
         self.digraph.edge(
             self.playbook_node.id,
             play_node.id,

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -54,6 +54,7 @@ class JSONRenderer(Renderer):
             json_builder.build_playbook(
                 hide_empty_plays=hide_empty_plays,
                 hide_plays_without_roles=hide_plays_without_roles,
+                show_handlers=show_handlers,
             )
 
             playbooks.append(json_builder.json_output)
@@ -91,12 +92,14 @@ class JSONPlaybookBuilder(PlaybookBuilder):
         self,
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
+        show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build a playbook.
 
         :param hide_empty_plays:
         :param hide_plays_without_roles:
+        :param show_handlers: Whether to show handlers or not
         :param kwargs:
         :return:
         """
@@ -107,6 +110,7 @@ class JSONPlaybookBuilder(PlaybookBuilder):
         self.json_output = self.playbook_node.to_dict(
             exclude_empty_plays=hide_empty_plays,
             exclude_plays_without_roles=hide_plays_without_roles,
+            include_handlers=show_handlers,
         )
 
         return json.dumps(self.json_output)

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -44,6 +44,7 @@ class JSONRenderer(Renderer):
         view: bool = False,
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
+        show_handlers: bool = False,
         **kwargs,
     ) -> str:
         playbooks = []
@@ -110,9 +111,12 @@ class JSONPlaybookBuilder(PlaybookBuilder):
 
         return json.dumps(self.json_output)
 
-    def build_play(self, play_node: PlayNode, **kwargs) -> None:
+    def build_play(
+        self, play_node: PlayNode, show_handlers: bool = False, **kwargs
+    ) -> None:
         """Not needed.
 
+        :param show_handlers:
         :param play_node:
         :param kwargs:
         :return:

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -97,7 +97,7 @@ class MermaidFlowChartRenderer(Renderer):
             mermaid_code += playbook_builder.build_playbook(
                 hide_empty_plays=hide_empty_plays,
                 hide_plays_without_roles=hide_plays_without_roles,
-                show_handlers=show_handlers
+                show_handlers=show_handlers,
             )
             link_order = playbook_builder.link_order
             roles_built.update(playbook_builder.roles_built)

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -47,6 +47,7 @@ class MermaidFlowChartRenderer(Renderer):
         view: bool = False,
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
+        show_handlers: bool = False,
         directive: str = DEFAULT_DIRECTIVE,
         orientation: str = DEFAULT_ORIENTATION,
         **kwargs,
@@ -59,6 +60,7 @@ class MermaidFlowChartRenderer(Renderer):
         :param view: Not supported for the moment.
         :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph.
         :param hide_plays_without_roles: Whether to hide plays without any roles or not.
+        :param show_handlers: Whether to show handlers or not.
         :param directive: Mermaid directive.
         :param orientation: Mermaid graph orientation.
         :param kwargs:
@@ -95,6 +97,7 @@ class MermaidFlowChartRenderer(Renderer):
             mermaid_code += playbook_builder.build_playbook(
                 hide_empty_plays=hide_empty_plays,
                 hide_plays_without_roles=hide_plays_without_roles,
+                show_handlers=show_handlers
             )
             link_order = playbook_builder.link_order
             roles_built.update(playbook_builder.roles_built)
@@ -173,6 +176,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self,
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
+        show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build a playbook.
@@ -180,6 +184,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         :param hide_plays_without_roles: Whether to hide plays without any roles or not
         :param hide_empty_plays: Whether to hide empty plays or not
         :param hide_plays_without_roles: Whether to hide plays without any roles or not
+        :param show_handlers: Whether to show handlers or not
         :param kwargs:
         :return:
         """
@@ -200,16 +205,19 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             exclude_empty=hide_empty_plays,
             exclude_without_roles=hide_plays_without_roles,
         ):
-            self.build_play(play_node)
+            self.build_play(play_node, show_handlers=show_handlers, **kwargs)
         self._indentation_level -= 1
 
         self.add_comment(f"End of the playbook '{self.playbook_node.display_name()}'\n")
 
         return self.mermaid_code
 
-    def build_play(self, play_node: PlayNode, **kwargs) -> None:
+    def build_play(
+        self, play_node: PlayNode, show_handlers: bool = False, **kwargs
+    ) -> None:
         """Build a play.
 
+        :param show_handlers:
         :param play_node:
         :param kwargs:
         :return:
@@ -235,7 +243,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
 
         # traverse the play
         self._indentation_level += 1
-        self.traverse_play(play_node)
+        self.traverse_play(play_node, show_handlers, **kwargs)
         self._indentation_level -= 1
 
         self.add_comment(f"End of the play '{play_node.display_name()}'")

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -272,7 +272,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             node_id=task_node.id,
             shape=node_shape,
             label=f"{node_label_prefix} {task_node.name}",
-            style=style
+            style=style,
         )
 
         # From parent to task

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -259,18 +259,20 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
 
         link_type = "--"
         node_shape = "rect"
+        style = f"stroke:{color},fill:{fontcolor}"
 
         if task_node.is_handler():
             # dotted style for handlers
             link_type = "-.-"
             node_shape = "hexagon"
+            style += ",stroke-dasharray: 2, 2"
 
         # Task node
         self.add_node(
             node_id=task_node.id,
             shape=node_shape,
             label=f"{node_label_prefix} {task_node.name}",
-            style=f"stroke:{color},fill:{fontcolor}",
+            style=style
         )
 
         # From parent to task

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -184,15 +184,15 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         :return:
         """
         display.vvv(
-            f"Converting the playbook '{self.playbook_node.name}' to mermaid format",
+            f"Converting the playbook '{self.playbook_node.display_name()}' to mermaid format",
         )
 
         # Playbook node
-        self.add_comment(f"Start of the playbook '{self.playbook_node.name}'")
+        self.add_comment(f"Start of the playbook '{self.playbook_node.display_name()}'")
         self.add_node(
             node_id=self.playbook_node.id,
             shape="rounded",
-            label=f"{self.playbook_node.name}",
+            label=f"{self.playbook_node.display_name()}",
         )
 
         self._indentation_level += 1
@@ -203,7 +203,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             self.build_play(play_node)
         self._indentation_level -= 1
 
-        self.add_comment(f"End of the playbook '{self.playbook_node.name}'\n")
+        self.add_comment(f"End of the playbook '{self.playbook_node.display_name()}'\n")
 
         return self.mermaid_code
 
@@ -216,7 +216,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         """
         # Play node
         color, play_font_color = play_node.colors
-        self.add_comment(f"Start of the play '{play_node.name}'")
+        self.add_comment(f"Start of the play '{play_node.display_name()}'")
 
         self.add_node(
             node_id=play_node.id,
@@ -238,7 +238,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.traverse_play(play_node)
         self._indentation_level -= 1
 
-        self.add_comment(f"End of the play '{play_node.name}'")
+        self.add_comment(f"End of the play '{play_node.display_name()}'")
 
     def build_task(
         self,
@@ -270,7 +270,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=task_node.id,
             shape=node_shape,
-            label=f"{task_node.display_name()}",
+            label=task_node.display_name(),
             style=style,
         )
 
@@ -325,7 +325,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         :param kwargs:
         :return:
         """
-        self.add_comment(f"Start of the role '{role_node.name}'")
+        self.add_comment(f"Start of the role '{role_node.display_name()}'")
 
         plays_using_this_role = len(self.roles_usage[role_node])
         node_color = color
@@ -351,7 +351,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=role_node.id,
             shape="stadium",
-            label=f"{role_node.display_name()}",
+            label=role_node.display_name(),
             style=f"fill:{node_color},color:{fontcolor},stroke:{node_color}",
         )
 
@@ -365,7 +365,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             )
         self._indentation_level -= 1
 
-        self.add_comment(f"End of the role '{role_node.name}'")
+        self.add_comment(f"End of the role '{role_node.display_name()}'")
 
     def build_block(
         self,
@@ -387,7 +387,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=block_node.id,
             shape="rect",
-            label=f"{block_node.display_name()}",
+            label=block_node.display_name(),
             style=f"fill:{color},color:{fontcolor},stroke:{color}",
         )
 

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -221,7 +221,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=play_node.id,
             shape="rect",
-            label=f"{play_node.name}",
+            label=f"{play_node.display_name()}",
             style=f"stroke:{color},fill:{color},color:{play_font_color}",
         )
 
@@ -255,7 +255,6 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         :param kwargs:
         :return:
         """
-        node_label_prefix = kwargs.get("node_label_prefix", "")
 
         link_type = "--"
         node_shape = "rect"
@@ -271,7 +270,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=task_node.id,
             shape=node_shape,
-            label=f"{node_label_prefix} {task_node.name}",
+            label=f"{task_node.display_name()}",
             style=style,
         )
 
@@ -352,7 +351,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=role_node.id,
             shape="stadium",
-            label=f"[role] {role_node.name}",
+            label=f"{role_node.display_name()}",
             style=f"fill:{node_color},color:{fontcolor},stroke:{node_color}",
         )
 
@@ -388,7 +387,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         self.add_node(
             node_id=block_node.id,
             shape="rect",
-            label=f"[block] {block_node.name}",
+            label=f"{block_node.display_name()}",
             style=f"fill:{color},color:{fontcolor},stroke:{color}",
         )
 

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -291,9 +291,22 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         :param style: The style of the node.
         :return:
         """
-        self.add_text(f'{node_id}@{{ shape: {shape}, label: "{label.strip()}" }}')
+        # To ensure backward compatibility with older versions of Mermaid, I'm still using the old syntax of defining the
+        # shape and label of the node.
+        # This method takes the shape name which is converted to the corresponding shape using the old syntax.
+        # See https://mermaid.js.org/syntax/flowchart.html#expanded-node-shapes-in-mermaid-flowcharts-v11-3-0
+        # Once Gitlab updates to mermaid >= 11.3.0 (https://gitlab.com/gitlab-org/gitlab/-/issues/491514), we can use the new syntax.
+        label = label.strip()
+        shapes_mapping = {
+            "rect": f'{node_id}["{label}"]',
+            "hexagon": f'{node_id}{{{{"{label}"}}}}',
+            "rounded": f'{node_id}("{label}")',
+            "stadium": f'{node_id}(["{label}"])',
+        }
 
-        if style != "":
+        self.add_text(shapes_mapping[shape])
+
+        if style.strip() != "":
             self.add_text(f"style {node_id} {style}")
 
     def build_role(

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Mohamed El Mouctar HAIDARA
+# Copyright (C) 2024 Mohamed El Mouctar HAIDARA
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,9 @@ target-version = "py310"
 [lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 select = ["E4", "E7", "E9", "F", "I", "RUF", "PTH", "ANN001", "PT", "W293"]
-ignore = []
+ignore = [
+    "F401" # Ignore unused imports because of this https://github.com/astral-sh/ruff/issues/1619
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/fixtures/handlers-in-role.yml
+++ b/tests/fixtures/handlers-in-role.yml
@@ -1,0 +1,20 @@
+- name: handler in role
+  hosts: localhost
+  gather_facts: false
+
+  pre_tasks:
+    - name: pre task
+      debug: msg="pre task"
+
+  roles:
+    - role: role-with-handlers
+
+  post_tasks:
+    - name: post task
+      debug: msg="post task"
+      changed_when: true
+      notify: restart postgres
+
+  handlers:
+    - name: restart postgres
+      assert: { that: true }

--- a/tests/fixtures/handlers-in-role.yml
+++ b/tests/fixtures/handlers-in-role.yml
@@ -3,14 +3,13 @@
   gather_facts: false
 
   pre_tasks:
-    - name: pre task
+    - name: My pre task debug
       debug: msg="pre task"
 
   roles:
     - role: role-with-handlers
-
   post_tasks:
-    - name: post task
+    - name: My post task debug
       debug: msg="post task"
       changed_when: true
       notify: restart postgres

--- a/tests/fixtures/handlers.yml
+++ b/tests/fixtures/handlers.yml
@@ -1,0 +1,58 @@
+- name: play 1 - handlers
+  hosts: localhost
+  gather_facts: false
+  pre_tasks:
+    - name: pre task
+      debug: msg="pre task"
+      changed_when: true
+      # TODO: this handler should be included in the graph at the end of pre_tasks
+      notify: restart mysql in the pre_tasks
+  tasks:
+    - name: foo
+      assert: { that: true }
+      changed_when: true
+      notify: restart mysql
+
+    - name: bar
+      assert: { that: true }
+      changed_when: true
+      notify: restart nginx
+
+  handlers:
+    - name: restart nginx
+      assert: { that: true }
+
+    - name: restart mysql
+      assert: { that: true }
+
+    - name: restart mysql in the pre_tasks
+      assert: { that: true }
+
+- name: play 2 - handlers with meta
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: foo
+      assert: { that: true }
+      changed_when: true
+      notify: restart postgres
+
+    - name: Debug
+      debug: msg="debug"
+
+    - name: Flush handlers (meta)
+      meta: flush_handlers
+
+    - name: bar
+      assert: { that: true }
+      notify: stop traefik
+
+  handlers:
+    - name: restart postgres
+      assert: { that: true }
+
+    - name: stop traefik
+      assert: { that: true }
+
+    - name: restart apache
+      assert: { that: true }

--- a/tests/fixtures/handlers.yml
+++ b/tests/fixtures/handlers.yml
@@ -5,7 +5,6 @@
     - name: pre task
       debug: msg="pre task"
       changed_when: true
-      # TODO: this handler should be included in the graph at the end of pre_tasks
       notify: restart mysql in the pre_tasks
   tasks:
     - name: foo

--- a/tests/fixtures/handlers.yml
+++ b/tests/fixtures/handlers.yml
@@ -46,6 +46,7 @@
 
     - name: bar
       assert: { that: true }
+      changed_when: true
       notify: stop traefik
 
   handlers:

--- a/tests/fixtures/handlers.yml
+++ b/tests/fixtures/handlers.yml
@@ -2,10 +2,12 @@
   hosts: localhost
   gather_facts: false
   pre_tasks:
-    - name: pre task
+    - name: My debug pre task
       debug: msg="pre task"
       changed_when: true
-      notify: restart mysql in the pre_tasks
+      notify:
+        - restart mysql in the pre_tasks
+        - restart nginx
   tasks:
     - name: foo
       assert: { that: true }

--- a/tests/fixtures/json-schemas/v1.json
+++ b/tests/fixtures/json-schemas/v1.json
@@ -103,6 +103,12 @@
                   "items": {
                     "$ref": "#/$defs/task"
                   }
+                },
+                "handlers": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/task"
+                  }
                 }
               },
               "required": [
@@ -148,7 +154,7 @@
           "type": "string"
         },
         "id": {
-          "pattern": "^(pre_task|task|post_task|role|block)_.+$",
+          "pattern": "^(pre_task|task|post_task|role|block|handler)_.+$",
           "type": "string"
         },
         "name": {

--- a/tests/fixtures/roles/role-with-handlers/handlers/main.yml
+++ b/tests/fixtures/roles/role-with-handlers/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart postgres from the role
+  assert: { that: true }

--- a/tests/fixtures/roles/role-with-handlers/tasks/main.yml
+++ b/tests/fixtures/roles/role-with-handlers/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Debug 1
+  debug: msg="My role with a handler"
+  notify: restart postgres from the role
+  changed_when: true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,30 @@ def test_cli_include_role_tasks(
 
 
 @pytest.mark.parametrize(
+    ("show_handlers_option", "expected"),
+    [(["--"], False), (["--show-handlers"], True)],
+    ids=["default", "include"],
+)
+def test_cli_show_handlers(
+    show_handlers_option: list[str],
+    expected: bool,
+) -> None:
+    """Test for show handlers options: --show-handlers
+
+    :param show_handlers_option:
+    :param expected:
+    :return:
+    """
+    args = [__prog__, *show_handlers_option, "playboook.yml"]
+
+    cli = PlaybookGrapherCLI(args)
+
+    cli.parse()
+
+    assert cli.options.show_handlers == expected
+
+
+@pytest.mark.parametrize(
     ("tags_option", "expected"),
     [
         (["--"], ["all"]),

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -113,6 +113,8 @@ def test_to_dict() -> None:
     play.add_node("post_tasks", TaskNode("task 2"))
     playbook.add_node("plays", play)
 
+    playbook.calculate_indices()
+
     dict_rep = playbook.to_dict(exclude_empty_plays=True)
 
     assert dict_rep["type"] == "PlaybookNode"

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -15,9 +15,9 @@ DIR_PATH = Path(__file__).parent.resolve()
 
 
 def run_grapher(
-        playbooks: list[str],
-        output_filename: str,
-        additional_args: list[str] | None = None,
+    playbooks: list[str],
+    output_filename: str,
+    additional_args: list[str] | None = None,
 ) -> tuple[str, list[str]]:
     """Utility function to run the grapher
     :param output_filename:
@@ -71,16 +71,16 @@ def run_grapher(
 
 
 def _common_tests(
-        svg_filename: str,
-        playbook_paths: list[str],
-        playbooks_number: int = 1,
-        plays_number: int = 0,
-        tasks_number: int = 0,
-        post_tasks_number: int = 0,
-        roles_number: int = 0,
-        pre_tasks_number: int = 0,
-        blocks_number: int = 0,
-        handlers_number: int = 0,
+    svg_filename: str,
+    playbook_paths: list[str],
+    playbooks_number: int = 1,
+    plays_number: int = 0,
+    tasks_number: int = 0,
+    post_tasks_number: int = 0,
+    roles_number: int = 0,
+    pre_tasks_number: int = 0,
+    blocks_number: int = 0,
+    handlers_number: int = 0,
 ) -> dict[str, list[Element]]:
     """Perform some common tests on the generated svg file:
      - Existence of svg file
@@ -112,39 +112,39 @@ def _common_tests(
 
     playbooks_file_names = [e.text for e in playbooks.find("text")]
     assert (
-            playbooks_file_names == playbook_paths
+        playbooks_file_names == playbook_paths
     ), "The playbook file names should be in the svg file"
 
     assert (
-            len(playbooks) == playbooks_number
+        len(playbooks) == playbooks_number
     ), f"The graph '{svg_filename}' should contains {playbooks_number} playbook(s) but we found {len(playbooks)} play(s)"
 
     assert (
-            len(plays) == plays_number
+        len(plays) == plays_number
     ), f"The graph '{svg_filename}' should contains {plays_number} play(s) but we found {len(plays)} play(s)"
 
     assert (
-            len(pre_tasks) == pre_tasks_number
+        len(pre_tasks) == pre_tasks_number
     ), f"The graph '{svg_filename}' should contains {pre_tasks_number} pre tasks(s) but we found {len(pre_tasks)} pre tasks"
 
     assert (
-            len(roles) == roles_number
+        len(roles) == roles_number
     ), f"The graph '{svg_filename}' should contains {roles_number} role(s) but we found {len(roles)} role(s)"
 
     assert (
-            len(tasks) == tasks_number
+        len(tasks) == tasks_number
     ), f"The graph '{svg_filename}' should contains {tasks_number} tasks(s) but we found {len(tasks)} tasks"
 
     assert (
-            len(post_tasks) == post_tasks_number
+        len(post_tasks) == post_tasks_number
     ), f"The graph '{svg_filename}' should contains {post_tasks_number} post tasks(s) but we found {len(post_tasks)} post tasks"
 
     assert (
-            len(blocks) == blocks_number
+        len(blocks) == blocks_number
     ), f"The graph '{svg_filename}' should contains {blocks_number} blocks(s) but we found {len(blocks)} blocks"
 
     assert (
-            len(handlers) == handlers_number
+        len(handlers) == handlers_number
     ), f"The graph '{svg_filename}' should contains {handlers_number} handlers(s) but we found {len(handlers)} handlers "
 
     return {
@@ -238,9 +238,9 @@ def test_import_tasks(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_with_roles(
-        request: pytest.FixtureRequest,
-        include_role_tasks_option: str,
-        expected_tasks_number: int,
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_tasks_number: int,
 ) -> None:
     """Test with_roles.yml, an example with roles."""
     svg_path, playbook_paths = run_grapher(
@@ -266,9 +266,9 @@ def test_with_roles(
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_include_role(
-        request: pytest.FixtureRequest,
-        include_role_tasks_option: str,
-        expected_tasks_number: int,
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_tasks_number: int,
 ) -> None:
     """Test include_role.yml, an example with include_role."""
     svg_path, playbook_paths = run_grapher(
@@ -328,9 +328,9 @@ def test_nested_include_tasks(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_import_role(
-        request: pytest.FixtureRequest,
-        include_role_tasks_option: str,
-        expected_tasks_number: int,
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_tasks_number: int,
 ) -> None:
     """Test import_role.yml, an example with import role.
     Import role is special because the tasks imported from role are treated as "normal tasks" when the playbook is parsed.
@@ -372,9 +372,9 @@ def test_import_playbook(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_nested_import_playbook(
-        request: pytest.FixtureRequest,
-        include_role_tasks_option: str,
-        expected_tasks_number: int,
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_tasks_number: int,
 ) -> None:
     """Test nested import playbook with an import_role and include_tasks."""
     svg_path, playbook_paths = run_grapher(
@@ -405,10 +405,10 @@ def test_relative_var_files(request: pytest.FixtureRequest) -> None:
 
     # check if the plays title contains the interpolated variables
     assert (
-            "Cristiano Ronaldo" in res["tasks"][0].find("g/a/text").text
+        "Cristiano Ronaldo" in res["tasks"][0].find("g/a/text").text
     ), "The title should contain player name"
     assert (
-            "Lionel Messi" in res["tasks"][1].find("g/a/text").text
+        "Lionel Messi" in res["tasks"][1].find("g/a/text").text
     ), "The title should contain player name"
 
 
@@ -482,7 +482,7 @@ def test_multi_playbooks(request: pytest.FixtureRequest) -> None:
 
 
 def test_with_roles_with_custom_protocol_handlers(
-        request: pytest.FixtureRequest,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test with_roles.yml with a custom protocol handlers."""
     formats_str = '{"file": "vscode://file/{path}:{line}", "folder": "{path}"}'
@@ -520,7 +520,7 @@ def test_with_roles_with_custom_protocol_handlers(
 
 
 def test_community_download_roles_and_collection(
-        request: pytest.FixtureRequest,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test if the grapher is able to find some downloaded roles and collections when graphing the playbook
     :return:
@@ -538,11 +538,11 @@ def test_community_download_roles_and_collection(
     ids=["no_group", "group"],
 )
 def test_group_roles_by_name(
-        request: pytest.FixtureRequest,
-        flag: str,
-        roles_number: int,
-        tasks_number: int,
-        post_tasks_number: int,
+    request: pytest.FixtureRequest,
+    flag: str,
+    roles_number: int,
+    tasks_number: int,
+    post_tasks_number: int,
 ) -> None:
     """Test group roles by name
     :return:
@@ -607,7 +607,7 @@ def test_hiding_empty_plays_with_tags_filter(request: pytest.FixtureRequest) -> 
 
 
 def test_hiding_empty_plays_with_tags_filter_all(
-        request: pytest.FixtureRequest,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test hiding plays with the flag --hide-empty-plays.
 
@@ -652,7 +652,7 @@ def test_hiding_plays_without_roles(request: pytest.FixtureRequest) -> None:
 
 
 def test_hiding_plays_without_roles_with_tags_filtering(
-        request: pytest.FixtureRequest,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Test hiding plays with the flag --hide-plays-without-roles.
 
@@ -688,7 +688,7 @@ def test_hiding_plays_without_roles_with_tags_filtering(
     ],
 )
 def test_graphing_a_playbook_in_a_collection(
-        request: pytest.FixtureRequest, playbook: str
+    request: pytest.FixtureRequest, playbook: str
 ) -> None:
     """Test graphing a playbook in a collection
 
@@ -718,9 +718,9 @@ def test_graphing_a_playbook_in_a_collection(
     ids=["no_handlers", "show_handlers"],
 )
 def test_handlers(
-        request: pytest.FixtureRequest,
-        flag: str,
-        handlers_number: int,
+    request: pytest.FixtureRequest,
+    flag: str,
+    handlers_number: int,
 ) -> None:
     """Test graphing a playbook with handlers
 
@@ -747,9 +747,9 @@ def test_handlers(
     ids=["no_handlers", "show_handlers"],
 )
 def test_handlers_in_role(
-        request: pytest.FixtureRequest,
-        flag: str,
-        handlers_number: int,
+    request: pytest.FixtureRequest,
+    flag: str,
+    handlers_number: int,
 ) -> None:
     """Test graphing a playbook with handlers
 

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -15,9 +15,9 @@ DIR_PATH = Path(__file__).parent.resolve()
 
 
 def run_grapher(
-    playbooks: list[str],
-    output_filename: str,
-    additional_args: list[str] | None = None,
+        playbooks: list[str],
+        output_filename: str,
+        additional_args: list[str] | None = None,
 ) -> tuple[str, list[str]]:
     """Utility function to run the grapher
     :param output_filename:
@@ -71,16 +71,16 @@ def run_grapher(
 
 
 def _common_tests(
-    svg_filename: str,
-    playbook_paths: list[str],
-    playbooks_number: int = 1,
-    plays_number: int = 0,
-    tasks_number: int = 0,
-    post_tasks_number: int = 0,
-    roles_number: int = 0,
-    pre_tasks_number: int = 0,
-    blocks_number: int = 0,
-    handlers_number: int = 0,
+        svg_filename: str,
+        playbook_paths: list[str],
+        playbooks_number: int = 1,
+        plays_number: int = 0,
+        tasks_number: int = 0,
+        post_tasks_number: int = 0,
+        roles_number: int = 0,
+        pre_tasks_number: int = 0,
+        blocks_number: int = 0,
+        handlers_number: int = 0,
 ) -> dict[str, list[Element]]:
     """Perform some common tests on the generated svg file:
      - Existence of svg file
@@ -112,40 +112,40 @@ def _common_tests(
 
     playbooks_file_names = [e.text for e in playbooks.find("text")]
     assert (
-        playbooks_file_names == playbook_paths
+            playbooks_file_names == playbook_paths
     ), "The playbook file names should be in the svg file"
 
     assert (
-        len(playbooks) == playbooks_number
+            len(playbooks) == playbooks_number
     ), f"The graph '{svg_filename}' should contains {playbooks_number} playbook(s) but we found {len(playbooks)} play(s)"
 
     assert (
-        len(plays) == plays_number
+            len(plays) == plays_number
     ), f"The graph '{svg_filename}' should contains {plays_number} play(s) but we found {len(plays)} play(s)"
 
     assert (
-        len(pre_tasks) == pre_tasks_number
+            len(pre_tasks) == pre_tasks_number
     ), f"The graph '{svg_filename}' should contains {pre_tasks_number} pre tasks(s) but we found {len(pre_tasks)} pre tasks"
 
     assert (
-        len(roles) == roles_number
+            len(roles) == roles_number
     ), f"The graph '{svg_filename}' should contains {roles_number} role(s) but we found {len(roles)} role(s)"
 
     assert (
-        len(tasks) == tasks_number
+            len(tasks) == tasks_number
     ), f"The graph '{svg_filename}' should contains {tasks_number} tasks(s) but we found {len(tasks)} tasks"
 
     assert (
-        len(post_tasks) == post_tasks_number
+            len(post_tasks) == post_tasks_number
     ), f"The graph '{svg_filename}' should contains {post_tasks_number} post tasks(s) but we found {len(post_tasks)} post tasks"
 
     assert (
-        len(blocks) == blocks_number
+            len(blocks) == blocks_number
     ), f"The graph '{svg_filename}' should contains {blocks_number} blocks(s) but we found {len(blocks)} blocks"
 
     assert (
-        len(handlers) == handlers_number
-    ), f"The graph '{svg_filename}' should contains {blocks_number} handlers(s) but we found {len(handlers)} handlers "
+            len(handlers) == handlers_number
+    ), f"The graph '{svg_filename}' should contains {handlers_number} handlers(s) but we found {len(handlers)} handlers "
 
     return {
         "tasks": tasks,
@@ -238,9 +238,9 @@ def test_import_tasks(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_with_roles(
-    request: pytest.FixtureRequest,
-    include_role_tasks_option: str,
-    expected_tasks_number: int,
+        request: pytest.FixtureRequest,
+        include_role_tasks_option: str,
+        expected_tasks_number: int,
 ) -> None:
     """Test with_roles.yml, an example with roles."""
     svg_path, playbook_paths = run_grapher(
@@ -266,9 +266,9 @@ def test_with_roles(
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_include_role(
-    request: pytest.FixtureRequest,
-    include_role_tasks_option: str,
-    expected_tasks_number: int,
+        request: pytest.FixtureRequest,
+        include_role_tasks_option: str,
+        expected_tasks_number: int,
 ) -> None:
     """Test include_role.yml, an example with include_role."""
     svg_path, playbook_paths = run_grapher(
@@ -328,9 +328,9 @@ def test_nested_include_tasks(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_import_role(
-    request: pytest.FixtureRequest,
-    include_role_tasks_option: str,
-    expected_tasks_number: int,
+        request: pytest.FixtureRequest,
+        include_role_tasks_option: str,
+        expected_tasks_number: int,
 ) -> None:
     """Test import_role.yml, an example with import role.
     Import role is special because the tasks imported from role are treated as "normal tasks" when the playbook is parsed.
@@ -372,9 +372,9 @@ def test_import_playbook(request: pytest.FixtureRequest) -> None:
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_nested_import_playbook(
-    request: pytest.FixtureRequest,
-    include_role_tasks_option: str,
-    expected_tasks_number: int,
+        request: pytest.FixtureRequest,
+        include_role_tasks_option: str,
+        expected_tasks_number: int,
 ) -> None:
     """Test nested import playbook with an import_role and include_tasks."""
     svg_path, playbook_paths = run_grapher(
@@ -405,10 +405,10 @@ def test_relative_var_files(request: pytest.FixtureRequest) -> None:
 
     # check if the plays title contains the interpolated variables
     assert (
-        "Cristiano Ronaldo" in res["tasks"][0].find("g/a/text").text
+            "Cristiano Ronaldo" in res["tasks"][0].find("g/a/text").text
     ), "The title should contain player name"
     assert (
-        "Lionel Messi" in res["tasks"][1].find("g/a/text").text
+            "Lionel Messi" in res["tasks"][1].find("g/a/text").text
     ), "The title should contain player name"
 
 
@@ -482,7 +482,7 @@ def test_multi_playbooks(request: pytest.FixtureRequest) -> None:
 
 
 def test_with_roles_with_custom_protocol_handlers(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
 ) -> None:
     """Test with_roles.yml with a custom protocol handlers."""
     formats_str = '{"file": "vscode://file/{path}:{line}", "folder": "{path}"}'
@@ -520,7 +520,7 @@ def test_with_roles_with_custom_protocol_handlers(
 
 
 def test_community_download_roles_and_collection(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
 ) -> None:
     """Test if the grapher is able to find some downloaded roles and collections when graphing the playbook
     :return:
@@ -538,11 +538,11 @@ def test_community_download_roles_and_collection(
     ids=["no_group", "group"],
 )
 def test_group_roles_by_name(
-    request: pytest.FixtureRequest,
-    flag: str,
-    roles_number: int,
-    tasks_number: int,
-    post_tasks_number: int,
+        request: pytest.FixtureRequest,
+        flag: str,
+        roles_number: int,
+        tasks_number: int,
+        post_tasks_number: int,
 ) -> None:
     """Test group roles by name
     :return:
@@ -607,7 +607,7 @@ def test_hiding_empty_plays_with_tags_filter(request: pytest.FixtureRequest) -> 
 
 
 def test_hiding_empty_plays_with_tags_filter_all(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
 ) -> None:
     """Test hiding plays with the flag --hide-empty-plays.
 
@@ -652,7 +652,7 @@ def test_hiding_plays_without_roles(request: pytest.FixtureRequest) -> None:
 
 
 def test_hiding_plays_without_roles_with_tags_filtering(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
 ) -> None:
     """Test hiding plays with the flag --hide-plays-without-roles.
 
@@ -688,7 +688,7 @@ def test_hiding_plays_without_roles_with_tags_filtering(
     ],
 )
 def test_graphing_a_playbook_in_a_collection(
-    request: pytest.FixtureRequest, playbook: str
+        request: pytest.FixtureRequest, playbook: str
 ) -> None:
     """Test graphing a playbook in a collection
 
@@ -712,8 +712,15 @@ def test_graphing_a_playbook_in_a_collection(
     )
 
 
+@pytest.mark.parametrize(
+    ("flag", "handlers_number"),
+    [("--", 0), ("--show-handlers", 6)],
+    ids=["no_handlers", "show_handlers"],
+)
 def test_handlers(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
+        flag: str,
+        handlers_number: int,
 ) -> None:
     """Test graphing a playbook with handlers
 
@@ -721,7 +728,7 @@ def test_handlers(
     :return:
     """
     svg_path, playbook_paths = run_grapher(
-        ["handlers.yml"], output_filename=request.node.name
+        ["handlers.yml"], output_filename=request.node.name, additional_args=[flag]
     )
 
     _common_tests(
@@ -730,12 +737,19 @@ def test_handlers(
         pre_tasks_number=1,
         plays_number=2,
         tasks_number=6,
-        handlers_number=6,
+        handlers_number=handlers_number,
     )
 
 
+@pytest.mark.parametrize(
+    ("flag", "handlers_number"),
+    [("--", 0), ("--show-handlers", 2)],
+    ids=["no_handlers", "show_handlers"],
+)
 def test_handlers_in_role(
-    request: pytest.FixtureRequest,
+        request: pytest.FixtureRequest,
+        flag: str,
+        handlers_number: int,
 ) -> None:
     """Test graphing a playbook with handlers
 
@@ -747,6 +761,7 @@ def test_handlers_in_role(
         output_filename=request.node.name,
         additional_args=[
             "--include-role-tasks",
+            flag,
         ],
     )
 
@@ -758,5 +773,5 @@ def test_handlers_in_role(
         tasks_number=1,
         post_tasks_number=1,
         roles_number=1,
-        handlers_number=2,
+        handlers_number=handlers_number,
     )

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -80,6 +80,7 @@ def _common_tests(
     roles_number: int = 0,
     pre_tasks_number: int = 0,
     blocks_number: int = 0,
+    handlers_number: int = 0,
 ) -> dict[str, list[Element]]:
     """Perform some common tests on the generated svg file:
      - Existence of svg file
@@ -91,6 +92,7 @@ def _common_tests(
     :param roles_number: Number of roles in the playbook
     :param tasks_number: Number of tasks in the playbook
     :param post_tasks_number: Number of post tasks in the playbook
+    :param handlers_number: Number of handlers in the playbook
     :return: A dictionary with the different tasks, roles, pre_tasks as keys and a list of Elements (nodes) as values.
     """
     # test if the file exists. It will exist only if we write in it.
@@ -106,6 +108,7 @@ def _common_tests(
     pre_tasks = pq("g[id^='pre_task_']")
     blocks = pq("g[id^='block_']")
     roles = pq("g[id^='role_']")
+    handlers = pq("g[id^='handler_']")
 
     playbooks_file_names = [e.text for e in playbooks.find("text")]
     assert (
@@ -138,7 +141,11 @@ def _common_tests(
 
     assert (
         len(blocks) == blocks_number
-    ), f"The graph '{svg_filename}' should contains {blocks_number} blocks(s) but we found {len(blocks)} blocks "
+    ), f"The graph '{svg_filename}' should contains {blocks_number} blocks(s) but we found {len(blocks)} blocks"
+
+    assert (
+        len(handlers) == handlers_number
+    ), f"The graph '{svg_filename}' should contains {blocks_number} handlers(s) but we found {len(handlers)} handlers "
 
     return {
         "tasks": tasks,
@@ -147,6 +154,7 @@ def _common_tests(
         "pre_tasks": pre_tasks,
         "roles": roles,
         "blocks": blocks,
+        "handlers": handlers,
     }
 
 
@@ -701,4 +709,54 @@ def test_graphing_a_playbook_in_a_collection(
         plays_number=1,
         roles_number=2,
         tasks_number=6,
+    )
+
+
+def test_handlers(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test graphing a playbook with handlers
+
+    :param request:
+    :return:
+    """
+    svg_path, playbook_paths = run_grapher(
+        ["handlers.yml"], output_filename=request.node.name
+    )
+
+    _common_tests(
+        svg_filename=svg_path,
+        playbook_paths=playbook_paths,
+        pre_tasks_number=1,
+        plays_number=2,
+        tasks_number=6,
+        handlers_number=6,
+    )
+
+
+def test_handlers_in_role(
+    request: pytest.FixtureRequest,
+) -> None:
+    """Test graphing a playbook with handlers
+
+    :param request:
+    :return:
+    """
+    svg_path, playbook_paths = run_grapher(
+        ["handlers-in-role.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "--include-role-tasks",
+        ],
+    )
+
+    _common_tests(
+        svg_filename=svg_path,
+        playbook_paths=playbook_paths,
+        pre_tasks_number=1,
+        plays_number=1,
+        tasks_number=1,
+        post_tasks_number=1,
+        roles_number=1,
+        handlers_number=2,
     )

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -278,11 +278,15 @@ def test_multi_playbooks(request: pytest.FixtureRequest) -> None:
     )
 
 
-def test_handlers(request: pytest.FixtureRequest) -> None:
+@pytest.mark.parametrize(
+    ("flag", "handlers_number"),
+    [("--", 0), ("--show-handlers", 6)],
+    ids=["no_handlers", "show_handlers"],
+)
+def test_handlers(
+    request: pytest.FixtureRequest, flag: str, handlers_number: int
+) -> None:
     """Test for handlers.
-
-    The JSON renderer additionally adds the handlers to the output in a separate section. As such, it has more handlers
-    than the other renderers.
 
     :param request:
     :return:"""
@@ -293,6 +297,7 @@ def test_handlers(request: pytest.FixtureRequest) -> None:
             "-i",
             str(INVENTORY_PATH),
             "--include-role-tasks",
+            flag,
         ],
     )
     _common_tests(
@@ -300,13 +305,19 @@ def test_handlers(request: pytest.FixtureRequest) -> None:
         plays_number=2,
         pre_tasks_number=1,
         tasks_number=6,
-        handlers_number=6,
+        handlers_number=handlers_number,
     )
 
 
-def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
-    """The JSON renderer additionally adds the handlers to the output in a separate section. As such, it has more handlers
-    than the other renderers.
+@pytest.mark.parametrize(
+    ("flag", "handlers_number"),
+    [("--", 0), ("--show-handlers", 2)],
+    ids=["no_handlers", "show_handlers"],
+)
+def test_handler_in_a_role(
+    request: pytest.FixtureRequest, flag: str, handlers_number: int
+) -> None:
+    """Test for handlers in the role.
 
     :param request:
     :return:
@@ -318,6 +329,7 @@ def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
             "-i",
             str(INVENTORY_PATH),
             "--include-role-tasks",
+            flag,
         ],
     )
     _common_tests(
@@ -326,6 +338,6 @@ def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
         pre_tasks_number=1,
         post_tasks_number=1,
         tasks_number=1,
-        handlers_number=2,
+        handlers_number=handlers_number,
         roles_number=1,
     )

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -61,8 +61,9 @@ def _common_tests(
     roles_number: int = 0,
     pre_tasks_number: int = 0,
     blocks_number: int = 0,
+    handlers_number: int = 0,
 ) -> dict:
-    """Do some checks on the generated json files.
+    """Do some checks on the generated JSON files.
 
     We are using JQ to avoid traversing the JSON ourselves (much easier).
     :param json_path:
@@ -75,7 +76,7 @@ def _common_tests(
         schema = json.load(schema_file)
 
     # If no exception is raised by validate(), the instance is valid.
-    # I currently don't use format but added it here to not forget to add in case I use in the future.
+    # I currently don't use format but added it here to not forget to add it in case I use in the future.
     validate(
         instance=output,
         schema=schema,
@@ -130,6 +131,14 @@ def _common_tests(
         .all()
     )
 
+    handlers = (
+        jq.compile(
+            '.. | objects | select(.type == "TaskNode" and (.id | startswith("handler_")))',
+        )
+        .input(output)
+        .all()
+    )
+
     assert (
         len(playbooks) == playbooks_number
     ), f"The file '{json_path}' should contains {playbooks_number} playbook(s) but we found {len(playbooks)} playbook(s)"
@@ -158,6 +167,10 @@ def _common_tests(
         len(blocks) == blocks_number
     ), f"The file '{json_path}' should contains {blocks_number} block(s) but we found {len(blocks)} blocks"
 
+    assert (
+        len(handlers) == handlers_number
+    ), f"The file '{json_path}' should contains {handlers_number} handler(s) but we found {len(handlers)} handlers"
+
     # Check the play
     for play in plays:
         assert (
@@ -171,6 +184,7 @@ def _common_tests(
         "pre_tasks": pre_tasks,
         "roles": roles,
         "blocks": blocks,
+        "handlers": handlers,
     }
 
 
@@ -261,4 +275,42 @@ def test_multi_playbooks(request: pytest.FixtureRequest) -> None:
         roles_number=10,
         tasks_number=35,
         post_tasks_number=4,
+    )
+
+
+def test_handlers(request: pytest.FixtureRequest) -> None:
+    """:return:"""
+    json_path, playbook_paths = run_grapher(
+        ["handlers.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "-i",
+            str(INVENTORY_PATH),
+            "--include-role-tasks",
+        ],
+    )
+    _common_tests(
+        json_path, plays_number=2, pre_tasks_number=1, tasks_number=6, handlers_number=6
+    )
+
+
+def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
+    """:return:"""
+    json_path, playbook_paths = run_grapher(
+        ["handlers-in-role.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "-i",
+            str(INVENTORY_PATH),
+            "--include-role-tasks",
+        ],
+    )
+    _common_tests(
+        json_path,
+        plays_number=1,
+        pre_tasks_number=1,
+        post_tasks_number=1,
+        tasks_number=1,
+        handlers_number=2,
+        roles_number=1,
     )

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -300,7 +300,7 @@ def test_handlers(request: pytest.FixtureRequest) -> None:
         plays_number=2,
         pre_tasks_number=1,
         tasks_number=6,
-        handlers_number=6 + 6,
+        handlers_number=6,
     )
 
 
@@ -326,6 +326,6 @@ def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
         pre_tasks_number=1,
         post_tasks_number=1,
         tasks_number=1,
-        handlers_number=3,
+        handlers_number=2,
         roles_number=1,
     )

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -279,7 +279,13 @@ def test_multi_playbooks(request: pytest.FixtureRequest) -> None:
 
 
 def test_handlers(request: pytest.FixtureRequest) -> None:
-    """:return:"""
+    """Test for handlers.
+
+    The JSON renderer additionally adds the handlers to the output in a separate section. As such, it has more handlers
+    than the other renderers.
+
+    :param request:
+    :return:"""
     json_path, playbook_paths = run_grapher(
         ["handlers.yml"],
         output_filename=request.node.name,
@@ -290,12 +296,21 @@ def test_handlers(request: pytest.FixtureRequest) -> None:
         ],
     )
     _common_tests(
-        json_path, plays_number=2, pre_tasks_number=1, tasks_number=6, handlers_number=6
+        json_path,
+        plays_number=2,
+        pre_tasks_number=1,
+        tasks_number=6,
+        handlers_number=6 + 6,
     )
 
 
 def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
-    """:return:"""
+    """The JSON renderer additionally adds the handlers to the output in a separate section. As such, it has more handlers
+    than the other renderers.
+
+    :param request:
+    :return:
+    """
     json_path, playbook_paths = run_grapher(
         ["handlers-in-role.yml"],
         output_filename=request.node.name,
@@ -311,6 +326,6 @@ def test_handler_in_a_role(request: pytest.FixtureRequest) -> None:
         pre_tasks_number=1,
         post_tasks_number=1,
         tasks_number=1,
-        handlers_number=2,
+        handlers_number=3,
         roles_number=1,
     )

--- a/tests/test_mermaid_renderer.py
+++ b/tests/test_mermaid_renderer.py
@@ -99,6 +99,8 @@ def _common_tests(mermaid_file_path: str, playbook_paths: list[str], **kwargs) -
         "with_block.yml",
         "with_roles.yml",
         "haidaram.test_collection.test",
+        "handlers.yml",
+        "handlers-in-role.yml",
     ],
 )
 def test_single_playbook(request: pytest.FixtureRequest, playbook: str) -> None:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -614,7 +614,7 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
         assert h.is_handler()
 
     # Second play
-    assert len(play_2.tasks) == 4, "The second play should have 4 tasks"
+    assert len(play_2.tasks) == 6, "The second play should have 6 tasks"
     play_1_expected_handler = [
         "restart postgres",
         "stop traefik",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -580,3 +580,72 @@ def test_parsing_playbook_in_collection(
     assert (
         len(all_tasks) == 4 + 2
     ), "There should be 6 tasks in the playbook: 4 from the roles and 2 from the tasks at the playbook level"
+
+
+@pytest.mark.parametrize("grapher_cli", [["handlers.yml"]], indirect=True)
+def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
+    """Test if we are able to get the handlers in each play and add them in the graph
+    :return:
+    """
+    parser = PlaybookParser(grapher_cli.options.playbooks[0])
+    playbook_node = parser.parse()
+    plays = playbook_node.plays()
+
+    assert len(plays) == 2
+    play_1, play_2 = playbook_node.plays()[0], playbook_node.plays()[1]
+
+    assert len(play_1.tasks) == 2, "The first play should have 2 tasks"
+    assert len(play_1.handlers) == 3, "The first play should have 3 handlers"
+    expected_names = [
+        "restart nginx",
+        "restart mysql",
+        "restart mysql in the pre_tasks",
+    ]
+
+    for idx, h in enumerate(play_1.handlers):
+        assert (
+            h.name == expected_names[idx]
+        ), f"The handler should be '{expected_names[idx]}'"
+        assert h.is_handler()
+
+    assert len(play_2.tasks) == 4, "The first play should have 4 tasks"
+    assert len(play_2.handlers) == 3, "The first play should have 3 handlers"
+    expected_names = [
+        "restart postgres",
+        "stop traefik",
+        "restart apache",
+    ]
+    for idx, h in enumerate(play_2.handlers):
+        assert (
+            h.name == expected_names[idx]
+        ), f"The handler should be '{expected_names[idx]}'"
+        assert h.is_handler()
+        assert h.location is not None
+
+
+@pytest.mark.parametrize("grapher_cli", [["handlers-in-role.yml"]], indirect=True)
+def test_parsing_handler_in_role(grapher_cli: PlaybookGrapherCLI) -> None:
+    """Test if we are able to get the handlers defined in a role and add them in the graph
+    :return:
+    """
+    parser = PlaybookParser(grapher_cli.options.playbooks[0], include_role_tasks=True)
+    playbook_node = parser.parse()
+    plays = playbook_node.plays()
+
+    assert len(plays) == 1
+    play = plays[0]
+    assert len(play.handlers) == 1, "The play should have 1 handler"
+    handler = play.handlers[0]
+    assert handler.name == "restart postgres"
+
+    assert len(play.roles) == 1, "The play should have 1 role"
+    role = play.roles[0]
+    assert len(role.tasks) == 1, "The role should have 1 task"
+    assert len(role.handlers) == 1, "The role should have 1 handler"
+
+    assert role.handlers[0].name == f"{role.name} : restart postgres from the role"
+    assert role.handlers[0].location is not None
+
+    assert (
+        len(set(play.handlers + role.handlers)) == 2
+    ), "The total number of handlers should be 2"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -594,19 +594,15 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
     assert len(plays) == 2
     play_1, play_2 = playbook_node.plays()[0], playbook_node.plays()[1]
 
-    assert (
-        len(play_1.pre_tasks) == 3
-    ), "The first play should have 3 pre_tasks (1 tasks and 2 handler)"
-    assert (
-        len(play_1.tasks) == 4
-    ), "The first play should have 4 tasks: 2 task and 2 handlers"
+    assert len(play_1.pre_tasks) == 1, "The first play should have 1 pre_tasks"
+    assert len(play_1.tasks) == 2, "The first play should have 2 tasks"
 
     play_1_expected_handlers = [
         "restart nginx",
         "restart mysql",
         "restart mysql in the pre_tasks",
     ]
-
+    assert len(play_1.handlers) == len(play_1_expected_handlers)
     for idx, h in enumerate(play_1.handlers):
         assert (
             h.name == play_1_expected_handlers[idx]
@@ -614,12 +610,13 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
         assert h.is_handler()
 
     # Second play
-    assert len(play_2.tasks) == 6, "The second play should have 6 tasks"
+    assert len(play_2.tasks) == 4, "The second play should have 6 tasks"
     play_1_expected_handler = [
         "restart postgres",
         "stop traefik",
         "restart apache",
     ]
+    assert len(play_2.handlers) == len(play_1_expected_handler)
     for idx, h in enumerate(play_2.handlers):
         assert (
             h.name == play_1_expected_handler[idx]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -594,9 +594,13 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
     assert len(plays) == 2
     play_1, play_2 = playbook_node.plays()[0], playbook_node.plays()[1]
 
-    assert len(play_1.pre_tasks) == 2, "The first play should have 2 pre_task: one regular and one handler"
-    assert len(play_1.tasks) == 2, "The first play should have 2 tasks"
-    assert len(play_1.handlers) == 3, "The first play should have 3 handlers"
+    assert (
+        len(play_1.pre_tasks) == 3
+    ), "The first play should have 3 pre_tasks (1 tasks and 2 handler)"
+    assert (
+        len(play_1.tasks) == 4
+    ), "The first play should have 4 tasks: 2 task and 2 handlers"
+
     play_1_expected_handlers = [
         "restart nginx",
         "restart mysql",
@@ -610,8 +614,7 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
         assert h.is_handler()
 
     # Second play
-    assert len(play_2.tasks) == 4, "The first play should have 4 tasks"
-    assert len(play_2.handlers) == 3, "The first play should have 3 handlers"
+    assert len(play_2.tasks) == 4, "The second play should have 4 tasks"
     play_1_expected_handler = [
         "restart postgres",
         "stop traefik",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -594,9 +594,10 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
     assert len(plays) == 2
     play_1, play_2 = playbook_node.plays()[0], playbook_node.plays()[1]
 
+    assert len(play_1.pre_tasks) == 2, "The first play should have 2 pre_task: one regular and one handler"
     assert len(play_1.tasks) == 2, "The first play should have 2 tasks"
     assert len(play_1.handlers) == 3, "The first play should have 3 handlers"
-    expected_names = [
+    play_1_expected_handlers = [
         "restart nginx",
         "restart mysql",
         "restart mysql in the pre_tasks",
@@ -604,21 +605,22 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
 
     for idx, h in enumerate(play_1.handlers):
         assert (
-            h.name == expected_names[idx]
-        ), f"The handler should be '{expected_names[idx]}'"
+            h.name == play_1_expected_handlers[idx]
+        ), f"The handler should be '{play_1_expected_handlers[idx]}'"
         assert h.is_handler()
 
+    # Second play
     assert len(play_2.tasks) == 4, "The first play should have 4 tasks"
     assert len(play_2.handlers) == 3, "The first play should have 3 handlers"
-    expected_names = [
+    play_1_expected_handler = [
         "restart postgres",
         "stop traefik",
         "restart apache",
     ]
     for idx, h in enumerate(play_2.handlers):
         assert (
-            h.name == expected_names[idx]
-        ), f"The handler should be '{expected_names[idx]}'"
+            h.name == play_1_expected_handler[idx]
+        ), f"The handler should be '{play_1_expected_handler[idx]}'"
         assert h.is_handler()
         assert h.location is not None
 


### PR DESCRIPTION
Related #214 


- Add the handlers to the graph with `--show-handlers`. **This is the initial support for handlers.** They are by default added at the end of the play and roles only. This doesn't reflect Ansible behavior. 
- Changes the shape of the graphviz node to make it consistent with Mermaid. The tasks will be rectangle instead of `octagon`: https://graphviz.org/doc/info/shapes.html
- Refactor how the node/task index are computed given we can now add handlers after all the tasks are parsed.
- Add a new `display_name()` method to the node for a friendly name for the graph. This removes the of passing the `node_label_prefix` in multiple places.
- Remove the class **CompositeTasksNode** as it is no longer needed anymore. 
- Remove the play name from the edge going from playbook to the plays. This was not consistent with the other edges.