### PR TITLE
fix: Properly handle tags on roles (refactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,27 @@
 
 ## What's Changed
 
-* feat: Add the handlers to the graph with `--show-handlers` (**the initial support for handlers**). They are by default added
-  at the end of the play and roles only. This might change in the future to actually reflect the handlers' behavior.
-* Changes the shape of the graphviz node to make it consistent with Mermaid. The tasks will be rectangle instead of
-  `octagon`: https://graphviz.org/doc/info/shapes.html
-* Refactor how the nodes and tasks indices are computed given we can now add handlers after all the tasks are parsed.
-* Add a new `display_name()` method to the node for a friendly name for the graph. This removes passing the
-  `node_label_prefix` in multiple places.
-* Remove the play name from the edge going from playbook to the plays. This was not consistent with the other edges.
+* feat: Add the handlers to the graph with `--show-handlers` (**initial support for handlers**). They are by default
+  added at the end of the play and roles only. This might change in the future to actually reflect the handlers' behavior.
+* **Changes the shape of the graphviz node to make it consistent with Mermaid. The tasks will be rectangle instead of
+  `octagon`: https://graphviz.org/doc/info/shapes.html**
+* **fix: Remove the play name from the edge going from playbook to the plays. This was not consistent with the other edges.**
 * feat: Add a new option `--title` to add a title to the graph by @haidaraM
   in https://github.com/haidaraM/ansible-playbook-grapher/pull/229. Default to 'Ansible Playbook Grapher'. The graphviz
   renderer will now use this as the title (label). The Mermaid renderer already has a title.
+* **fix: The tags on the role itself should not be evaluated. Instead, what we care about is the tasks (they inherit the
+  tags set on the roles).** More
+  info [here.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html#adding-tags-to-roles)
+* "Empty roles" are no longer displayed by default. An empty role is a role with no tasks (after applying the tags
+  filters, for example). This is the same behavior as the option `--hide-empty-plays` but with roles. **I will eventually
+  drop `--hide-empty-plays` to make this the default behavior in the future.**
+* docs: Add a comparison matrix for the different renderers
+* (Internal) Moved some flags out of the parser to the renderer instead. The whole playbook and all the tasks and
+  roles (except the excluded ones) are always parsed. The renderer(s) will decide later what do based on the flags
+* (Internal) Refactor how the nodes and tasks indices are computed given we can now add handlers after all the tasks are
+  parsed.
+* (Internal) Add a new `display_name()` method to the node for a friendly name for the graph. This removes passing the
+  `node_label_prefix` in multiple places.
 
 **Full Changelog**: https://github.com/haidaraM/ansible-playbook-grapher/compare/v2.7.0...v2.8.0
 

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ More information [here](https://docs.ansible.com/ansible/latest/reference_append
 - **Ansible Handlers**: The handlers are partially supported for the moment. Their position in the graph doesn't entirely
   reflect their real order of execution in the playbook. They are displayed at the end of the play and roles, but they
   might be executed before that.
+- Looping on tasks is not supported. The tasks using loop are displayed as a single task.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -417,68 +417,154 @@ usage: ansible-playbook-grapher [-h] [-v] [--exclude-roles EXCLUDE_ROLES] [--onl
                                 [--renderer {graphviz,mermaid-flowchart,json}]
                                 [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
                                 [--renderer-mermaid-orientation {TD,RL,BT,RL,LR}] [--version] [--hide-plays-without-roles]
-                                [--hide-empty-plays] [--show-handlers] [-t TAGS] [--skip-tags SKIP_TAGS] [--vault-id VAULT_IDS] [-J |
-                                --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
+                                [--hide-empty-plays] [--title TITLE] [--show-handlers] [-t TAGS] [--skip-tags SKIP_TAGS]
+                                [--vault-id VAULT_IDS] [-J | --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
                                 playbooks [playbooks ...]
 
 Make graphs from your Ansible Playbooks.
 
 positional arguments:
-  playbooks             Playbook(s) to graph. You can specify multiple playbooks, separated by spaces and reference playbooks in collections.
+  playbooks             Playbook(s) to graph. You can specify multiple playbooks, separated by spaces and reference playbooks in
+                        collections.
 
 options:
   --exclude-roles EXCLUDE_ROLES
-			Specify file path or comma separated list of roles, which should be excluded. This argument may be specified multiple times.
+                        Specify file path or comma separated list of roles, which should be excluded. This argument may be specified
+                        multiple times.
   --group-roles-by-name
-                        When rendering the graph (graphviz and mermaid), only a single role will be displayed for all roles having the same names. Default: False
+                        When rendering the graph (graphviz and mermaid), only a single role will be displayed for all roles having the
+                        same names. Default: False
   --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter).
   --hide-plays-without-roles
-                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as tasks are
-                        considered (no import_role).
-  --include-role-tasks  Include the tasks of the roles in the graph.
-  --only-roles          Only render the roles in the graph (ignoring the tasks).
+                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play
+                        level and include_role as tasks are considered (no import_role).
+  --include-role-tasks  Include the tasks of the roles in the graph. Default: False
+  --only-roles          Only render the roles in the graph (ignoring the tasks)
   --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
-                        The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to custom. You should provide a
-                        JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to open folders (roles) inside the browser and files
-                        (tasks) in vscode, set it to: '{"file": "vscode://file/{path}:{line}:{column}", "folder": "{path}"}'. path: the absolute path to the
-                        file containing the the plays/tasks/roles. line/column: the position of the plays/tasks/roles in the file. You can optionally add the
-                        attribute "remove_from_path" to remove some parts of the path if you want relative paths.
+                        The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to
+                        custom. You should provide a JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to
+                        open folders (roles) inside the browser and files (tasks) in vscode, set it to: '{"file":
+                        "vscode://file/{path}:{line}:{column}", "folder": "{path}"}'. path: the absolute path to the file containing
+                        the the plays/tasks/roles. line/column: the position of the plays/tasks/roles in the file. You can optionally
+                        add the attribute "remove_from_path" to remove some parts of the path if you want relative paths.
   --open-protocol-handler {default,vscode,custom}
-                        The protocol to use to open the nodes when double-clicking on them in your SVG viewer (only for graphviz). Your SVG viewer must support
-                        double-click and Javascript. The supported values are 'default', 'vscode' and 'custom'. For 'default', the URL will be the path to the
-                        file or folders. When using a browser, it will open or download them. For 'vscode', the folders and files will be open with VSCode. For
-                        'custom', you need to set a custom format with --open-protocol-custom-formats.
+                        The protocol to use to open the nodes when double-clicking on them in your SVG viewer (only for graphviz). Your
+                        SVG viewer must support double-click and Javascript. The supported values are 'default', 'vscode' and 'custom'.
+                        For 'default', the URL will be the path to the file or folders. When using a browser, it will open or download
+                        them. For 'vscode', the folders and files will be open with VSCode. For 'custom', you need to set a custom
+                        format with --open-protocol-custom-formats.
   --renderer {graphviz,mermaid-flowchart,json}
                         The renderer to use to generate the graph. Default: graphviz
   --renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE
-                        The directive for the mermaid renderer. Can be used to customize the output: fonts, theme, curve etc. More info at
-                        https://mermaid.js.org/config/directives.html. Default: '%%{ init: { "flowchart": { "curve": "bumpX" } } }%%'
+                        The directive for the mermaid renderer. Can be used to customize the output: fonts, theme, curve etc. More info
+                        at https://mermaid.js.org/config/directives.html. Default: '%%{ init: { "flowchart": { "curve": "bumpX" } }
+                        }%%'
   --renderer-mermaid-orientation {TD,RL,BT,RL,LR}
                         The orientation of the flow chart. Default: 'LR'
   --show-handlers       Show the handlers in the graph. See the limitations in the project README on GitHub.
   --skip-tags SKIP_TAGS
                         only run plays and tasks whose tags do not match these values. This argument may be specified multiple times.
-   --title TITLE         The title to display in the graph. Default: 'Ansible Playbook Grapher'. Set it to an empty string to remove the
+  --title TITLE         The title to display in the graph. Default: 'Ansible Playbook Grapher'. Set it to an empty string to remove the
                         title.
   --vault-id VAULT_IDS  the vault identity to use. This argument may be specified multiple times.
-  --vault-password-file VAULT_PASSWORD_FILES, --vault-pass-file VAULT_PASSWORD_FILES
+  --vault-password-file, --vault-pass-file VAULT_PASSWORD_FILES
                         vault password file
   --version             show program's version number and exit
   --view                Automatically open the resulting SVG file with your system's default viewer application for the file type
   -J, --ask-vault-password, --ask-vault-pass
                         ask for vault password
-  -e EXTRA_VARS, --extra-vars EXTRA_VARS
-                        set additional variables as key=value or YAML/JSON, if filename prepend with @. This argument may be specified multiple times.
+  -e, --extra-vars EXTRA_VARS
+                        set additional variables as key=value or YAML/JSON, if filename prepend with @. This argument may be specified
+                        multiple times.
   -h, --help            show this help message and exit
-  -i INVENTORY, --inventory INVENTORY
+  -i, --inventory INVENTORY
                         Specify inventory host path or comma separated host list. This argument may be specified multiple times.
-  -o OUTPUT_FILENAME, --output-file-name OUTPUT_FILENAME
-                        Output filename without the '.svg' extension (for graphviz), '.mmd' for Mermaid or `.json`. The extension will be added automatically.
+  -o, --output-file-name OUTPUT_FILENAME
+                        Output filename without the '.svg' extension (for graphviz), '.mmd' for Mermaid or `.json`. The extension will
+                        be added automatically.
   -s, --save-dot-file   Save the graphviz dot file used to generate the graph.
-  -t TAGS, --tags TAGS  only run plays and tasks tagged with these values. This argument may be specified multiple times.
-  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin plugins currently evaluate up
-                        to -vvvvvv. A reasonable level to start is -vvv, connection debugging might require -vvvv. This argument may be specified multiple
-                        times.
+  -t, --tags TAGS       only run plays and tasks tagged with these values. This argument may be specified multiple times.
+  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin
+                        plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, connection debugging might
+                        require -vvvv. This argument may be specified multiple times.
+❯ ansible-playbook-grapher --help | pbcopy
+❯ ansible-playbook-grapher --help
+usage: ansible-playbook-grapher [-h] [-v] [--exclude-roles EXCLUDE_ROLES] [--only-roles] [-i INVENTORY] [--include-role-tasks] [-s]
+                                [--view] [-o OUTPUT_FILENAME] [--open-protocol-handler {default,vscode,custom}]
+                                [--open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS] [--group-roles-by-name]
+                                [--renderer {graphviz,mermaid-flowchart,json}]
+                                [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
+                                [--renderer-mermaid-orientation {TD,RL,BT,RL,LR}] [--version] [--hide-plays-without-roles]
+                                [--hide-empty-plays] [--title TITLE] [--show-handlers] [-t TAGS] [--skip-tags SKIP_TAGS]
+                                [--vault-id VAULT_IDS] [-J | --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
+                                playbooks [playbooks ...]
+
+Make graphs from your Ansible Playbooks.
+
+positional arguments:
+  playbooks             Playbook(s) to graph. You can specify multiple playbooks, separated by spaces and reference playbooks in
+                        collections.
+
+options:
+  --exclude-roles EXCLUDE_ROLES
+                        Specify file path or comma separated list of roles, which should be excluded. This argument may be specified
+                        multiple times.
+  --group-roles-by-name
+                        When rendering the graph (graphviz and mermaid), only a single role will be displayed for all roles having the
+                        same names. Default: False
+  --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter).
+  --hide-plays-without-roles
+                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play
+                        level and include_role as tasks are considered (no import_role).
+  --include-role-tasks  Include the tasks of the roles in the graph. Default: False
+  --only-roles          Only render the roles in the graph (ignoring the tasks)
+  --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
+                        The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to
+                        custom. You should provide a JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to
+                        open folders (roles) inside the browser and files (tasks) in vscode, set it to: '{"file":
+                        "vscode://file/{path}:{line}:{column}", "folder": "{path}"}'. path: the absolute path to the file containing
+                        the the plays/tasks/roles. line/column: the position of the plays/tasks/roles in the file. You can optionally
+                        add the attribute "remove_from_path" to remove some parts of the path if you want relative paths.
+  --open-protocol-handler {default,vscode,custom}
+                        The protocol to use to open the nodes when double-clicking on them in your SVG viewer (only for graphviz). Your
+                        SVG viewer must support double-click and Javascript. The supported values are 'default', 'vscode' and 'custom'.
+                        For 'default', the URL will be the path to the file or folders. When using a browser, it will open or download
+                        them. For 'vscode', the folders and files will be open with VSCode. For 'custom', you need to set a custom
+                        format with --open-protocol-custom-formats.
+  --renderer {graphviz,mermaid-flowchart,json}
+                        The renderer to use to generate the graph. Default: graphviz
+  --renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE
+                        The directive for the mermaid renderer. Can be used to customize the output: fonts, theme, curve etc. More info
+                        at https://mermaid.js.org/config/directives.html. Default: '%%{ init: { "flowchart": { "curve": "bumpX" } }
+                        }%%'
+  --renderer-mermaid-orientation {TD,RL,BT,RL,LR}
+                        The orientation of the flow chart. Default: 'LR'
+  --show-handlers       Show the handlers in the graph. See the limitations in the project README on GitHub.
+  --skip-tags SKIP_TAGS
+                        only run plays and tasks whose tags do not match these values. This argument may be specified multiple times.
+  --title TITLE         The title to display in the graph. Default: 'Ansible Playbook Grapher'. Set it to an empty string to remove the
+                        title.
+  --vault-id VAULT_IDS  the vault identity to use. This argument may be specified multiple times.
+  --vault-password-file, --vault-pass-file VAULT_PASSWORD_FILES
+                        vault password file
+  --version             show program's version number and exit
+  --view                Automatically open the resulting SVG file with your system's default viewer application for the file type
+  -J, --ask-vault-password, --ask-vault-pass
+                        ask for vault password
+  -e, --extra-vars EXTRA_VARS
+                        set additional variables as key=value or YAML/JSON, if filename prepend with @. This argument may be specified
+                        multiple times.
+  -h, --help            show this help message and exit
+  -i, --inventory INVENTORY
+                        Specify inventory host path or comma separated host list. This argument may be specified multiple times.
+  -o, --output-file-name OUTPUT_FILENAME
+                        Output filename without the '.svg' extension (for graphviz), '.mmd' for Mermaid or `.json`. The extension will
+                        be added automatically.
+  -s, --save-dot-file   Save the graphviz dot file used to generate the graph.
+  -t, --tags TAGS       only run plays and tasks tagged with these values. This argument may be specified multiple times.
+  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin
+                        plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, connection debugging might
+                        require -vvvv. This argument may be specified multiple times.
 ```
 
 ## Configuration: ansible.cfg

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ For example `TAGS_RUN` and `TAGS_SKIP` or vault configuration.
 
 More information [here](https://docs.ansible.com/ansible/latest/reference_appendices/config.html).
 
-## Limitations
+## Limitations and notes
 
 - Since Ansible Playbook Grapher is a static analyzer that parses your playbook, it's limited to what can be determined
   statically: no task is run against your inventory. The parser tries to interpolate the variables, but some of them are

--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ At the time of writing, two renderers are supported:
 
 Comparison of the renderers:
 
-|                                                    | Graphviz (.svg) | Mermaid Flowchart (.mmd) |                       JSON (.json)                       |
-|----------------------------------------------------|:---------------:|:------------------------:|:--------------------------------------------------------:|
-| Click on nodes to open the files (open protocol)   |        ✅        |            ❌             |          ✅: the file location is in the output           |
-| Highlight on hover                                 |        ✅        |            ❌             |                          ❌: NA                           |
-| Change graph orientation                           |        ❌        |            ✅             |                          ❌: NA                           |
-| Group roles by name                                |        ✅        |            ✅             | ✅: the roles with the same names will have the same IDs. |
-| Hide empty roles                                   |        ✅        |            ✅             |        ❌: The empty roles are kept in the output         |
-| View the output file in your the OS default viewer |        ✅        |            ✅             |                            ✅                             |
-| Tests                                              |    Automatic    |  Manual (need a parser)  |                        Automatic                         |
+|                                                          | `graphviz` (.svg) | `mermaid-flowchart` (.mmd) |                      `json` (.json)                      |
+|----------------------------------------------------------|:-----------------:|:--------------------------:|:--------------------------------------------------------:|
+| Click on nodes to open the files (open protocol handler) |         ✅         |             ❌              |          ✅: the file location is in the output           |
+| Highlight on hover                                       |         ✅         |             ❌              |                          ❌: NA                           |
+| Change graph orientation                                 |         ❌         |             ✅              |                          ❌: NA                           |
+| Group roles by name                                      |         ✅         |             ✅              | ✅: the roles with the same names will have the same IDs. |
+| Hide empty roles                                         |         ✅         |             ✅              |        ❌: The empty roles are kept in the output         |
+| View the output file in your the OS default viewer       |         ✅         |             ✅              |                            ✅                             |
+| Tests of the output                                      |     Automatic     |   Manual (need a parser)   |                        Automatic                         |
 
 If you are interested to support more renderers, feel free to create an issue or raise a PR based on the existing
 renderers.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ JavaScript:
   Lastly, you can provide your own protocol formats
   with `--open-protocol-handler custom --open-protocol-custom-formats '{}'`. See the help
   and [an example.](https://github.com/haidaraM/ansible-playbook-grapher/blob/34e0aef74b82808dceb6ccfbeb333c0b531eac12/ansibleplaybookgrapher/renderer/__init__.py#L32-L41)
-  To not confuse with [Ansible Handlers.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html)
+  To not confuse
+  with [Ansible Handlers.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_handlers.html)
 - Export the dot file used to generate the graph with Graphviz.
 
 ## Prerequisites
@@ -82,7 +83,19 @@ At the time of writing, two renderers are supported:
    and [other integrations](https://mermaid.js.org/ecosystem/integrations.html)) will render it.
 3. `json`: Generate a JSON representation of the graph. The corresponding JSON schema
    is [here.](https://github.com/haidaraM/ansible-playbook-grapher/tree/main/tests/fixtures/json-schemas) The JSON
-   output will give you more flexibility to create your own renderer.
+   output will give you more flexibility to create your own renderer outside the grapher.
+
+Comparison of the renderers:
+
+|                                                    | Graphviz (.svg) | Mermaid Flowchart (.mmd) |                       JSON (.json)                       |
+|----------------------------------------------------|:---------------:|:------------------------:|:--------------------------------------------------------:|
+| Click on nodes to open the files (open protocol)   |        ✅        |            ❌             |          ✅: the file location is in the output           |
+| Highlight on hover                                 |        ✅        |            ❌             |                          ❌: NA                           |
+| Change graph orientation                           |        ❌        |            ✅             |                          ❌: NA                           |
+| Group roles by name                                |        ✅        |            ✅             | ✅: the roles with the same names will have the same IDs. |
+| Hide empty roles                                   |        ✅        |            ✅             |        ❌: The empty roles are kept in the output         |
+| View the output file in your the OS default viewer |        ✅        |            ✅             |                            ✅                             |
+| Tests                                              |    Automatic    |  Manual (need a parser)  |                        Automatic                         |
 
 If you are interested to support more renderers, feel free to create an issue or raise a PR based on the existing
 renderers.
@@ -117,191 +130,191 @@ title: Ansible Playbook Grapher
 ---
 %%{ init: { "flowchart": { "curve": "bumpX" } } }%%
 flowchart LR
-	%% Start of the playbook 'tests/fixtures/multi-plays.yml'
-	playbook_a27d9bec("tests/fixtures/multi-plays.yml")
-		%% Start of the play 'Play: all (0)'
-		play_d6dd122d["Play: all (0)"]
-		style play_d6dd122d stroke:#ba1a12,fill:#ba1a12,color:#ffffff
-		playbook_a27d9bec --> |"1"| play_d6dd122d
-		linkStyle 0 stroke:#ba1a12,color:#ba1a12
-			pre_task_676cdcb1["[pre_task] Pretask"]
-			style pre_task_676cdcb1 stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"1"| pre_task_676cdcb1
-			linkStyle 1 stroke:#ba1a12,color:#ba1a12
-			pre_task_44476583["[pre_task] Pretask 2"]
-			style pre_task_44476583 stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"2"| pre_task_44476583
-			linkStyle 2 stroke:#ba1a12,color:#ba1a12
-			%% Start of the role '[role] fake_role'
-			play_d6dd122d --> |"3"| role_f0c07194
-			linkStyle 3 stroke:#ba1a12,color:#ba1a12
-			role_f0c07194(["[role] fake_role"])
-			style role_f0c07194 fill:#ba1a12,color:#ffffff,stroke:#ba1a12
-				task_90876ffc["[task] fake_role : Debug 1"]
-				style task_90876ffc stroke:#ba1a12,fill:#ffffff
-				role_f0c07194 --> |"1 [when: ansible_distribution == 'Debian']"| task_90876ffc
-				linkStyle 4 stroke:#ba1a12,color:#ba1a12
-				task_bb701882["[task] fake_role : Debug 2"]
-				style task_bb701882 stroke:#ba1a12,fill:#ffffff
-				role_f0c07194 --> |"2 [when: ansible_distribution == 'Debian']"| task_bb701882
-				linkStyle 5 stroke:#ba1a12,color:#ba1a12
-				task_c00c5d61["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-				style task_c00c5d61 stroke:#ba1a12,fill:#ffffff
-				role_f0c07194 --> |"3 [when: ansible_distribution == 'Debian']"| task_c00c5d61
-				linkStyle 6 stroke:#ba1a12,color:#ba1a12
-			%% End of the role '[role] fake_role'
-			%% Start of the role '[role] display_some_facts'
-			play_d6dd122d --> |"4"| role_a168caef
-			linkStyle 7 stroke:#ba1a12,color:#ba1a12
-			role_a168caef(["[role] display_some_facts"])
-			style role_a168caef fill:#ba1a12,color:#ffffff,stroke:#ba1a12
-				task_737e2be9["[task] display_some_facts : ansible_architecture"]
-				style task_737e2be9 stroke:#ba1a12,fill:#ffffff
-				role_a168caef --> |"1"| task_737e2be9
-				linkStyle 8 stroke:#ba1a12,color:#ba1a12
-				task_61bbb3fb["[task] display_some_facts : ansible_date_time"]
-				style task_61bbb3fb stroke:#ba1a12,fill:#ffffff
-				role_a168caef --> |"2"| task_61bbb3fb
-				linkStyle 9 stroke:#ba1a12,color:#ba1a12
-				task_3b7308dc["[task] display_some_facts : Specific included task for Debian"]
-				style task_3b7308dc stroke:#ba1a12,fill:#ffffff
-				role_a168caef --> |"3"| task_3b7308dc
-				linkStyle 10 stroke:#ba1a12,color:#ba1a12
-			%% End of the role '[role] display_some_facts'
-			task_c8b76065["[task] Add backport {{backport}}"]
-			style task_c8b76065 stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"5"| task_c8b76065
-			linkStyle 11 stroke:#ba1a12,color:#ba1a12
-			task_f7cebcbb["[task] Install packages"]
-			style task_f7cebcbb stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"6"| task_f7cebcbb
-			linkStyle 12 stroke:#ba1a12,color:#ba1a12
-			post_task_caafa665["[post_task] Posttask"]
-			style post_task_caafa665 stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"7"| post_task_caafa665
-			linkStyle 13 stroke:#ba1a12,color:#ba1a12
-			post_task_b5ade468["[post_task] Posttask 2"]
-			style post_task_b5ade468 stroke:#ba1a12,fill:#ffffff
-			play_d6dd122d --> |"8"| post_task_b5ade468
-			linkStyle 14 stroke:#ba1a12,color:#ba1a12
-		%% End of the play 'Play: all (0)'
-		%% Start of the play 'Play: database (0)'
-		play_d780677e["Play: database (0)"]
-		style play_d780677e stroke:#686864,fill:#686864,color:#ffffff
-		playbook_a27d9bec --> |"2"| play_d780677e
-		linkStyle 15 stroke:#686864,color:#686864
-			%% Start of the role '[role] fake_role'
-			play_d780677e --> |"1"| role_1e6bf323
-			linkStyle 16 stroke:#686864,color:#686864
-			role_1e6bf323(["[role] fake_role"])
-			style role_1e6bf323 fill:#686864,color:#ffffff,stroke:#686864
-				task_3cb17d25["[task] fake_role : Debug 1"]
-				style task_3cb17d25 stroke:#686864,fill:#ffffff
-				role_1e6bf323 --> |"1 [when: ansible_distribution == 'Debian']"| task_3cb17d25
-				linkStyle 17 stroke:#686864,color:#686864
-				task_1f6232f4["[task] fake_role : Debug 2"]
-				style task_1f6232f4 stroke:#686864,fill:#ffffff
-				role_1e6bf323 --> |"2 [when: ansible_distribution == 'Debian']"| task_1f6232f4
-				linkStyle 18 stroke:#686864,color:#686864
-				task_0361ffa3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-				style task_0361ffa3 stroke:#686864,fill:#ffffff
-				role_1e6bf323 --> |"3 [when: ansible_distribution == 'Debian']"| task_0361ffa3
-				linkStyle 19 stroke:#686864,color:#686864
-			%% End of the role '[role] fake_role'
-			%% Start of the role '[role] display_some_facts'
-			play_d780677e --> |"2"| role_a8b4b712
-			linkStyle 20 stroke:#686864,color:#686864
-			role_a8b4b712(["[role] display_some_facts"])
-			style role_a8b4b712 fill:#686864,color:#ffffff,stroke:#686864
-				task_c1d17653["[task] display_some_facts : ansible_architecture"]
-				style task_c1d17653 stroke:#686864,fill:#ffffff
-				role_a8b4b712 --> |"1"| task_c1d17653
-				linkStyle 21 stroke:#686864,color:#686864
-				task_8353a2ef["[task] display_some_facts : ansible_date_time"]
-				style task_8353a2ef stroke:#686864,fill:#ffffff
-				role_a8b4b712 --> |"2"| task_8353a2ef
-				linkStyle 22 stroke:#686864,color:#686864
-				task_d8141ffa["[task] display_some_facts : Specific included task for Debian"]
-				style task_d8141ffa stroke:#686864,fill:#ffffff
-				role_a8b4b712 --> |"3"| task_d8141ffa
-				linkStyle 23 stroke:#686864,color:#686864
-			%% End of the role '[role] display_some_facts'
-		%% End of the play 'Play: database (0)'
-		%% Start of the play 'Play: webserver (0)'
-		play_4d3ee472["Play: webserver (0)"]
-		style play_4d3ee472 stroke:#43418b,fill:#43418b,color:#ffffff
-		playbook_a27d9bec --> |"3"| play_4d3ee472
-		linkStyle 24 stroke:#43418b,color:#43418b
-			%% Start of the role '[role] nested_include_role'
-			play_4d3ee472 --> |"1"| role_f611e648
-			linkStyle 25 stroke:#43418b,color:#43418b
-			role_f611e648(["[role] nested_include_role"])
-			style role_f611e648 fill:#43418b,color:#ffffff,stroke:#43418b
-				task_8d2e4414["[task] nested_include_role : Ensure postgresql is at the latest version"]
-				style task_8d2e4414 stroke:#43418b,fill:#ffffff
-				role_f611e648 --> |"1"| task_8d2e4414
-				linkStyle 26 stroke:#43418b,color:#43418b
-				task_d1bc52f0["[task] nested_include_role : Ensure that postgresql is started"]
-				style task_d1bc52f0 stroke:#43418b,fill:#ffffff
-				role_f611e648 --> |"2"| task_d1bc52f0
-				linkStyle 27 stroke:#43418b,color:#43418b
-				%% Start of the role '[role] display_some_facts'
-				role_f611e648 --> |"3 [when: x is not defined]"| role_39ad2981
-				linkStyle 28 stroke:#43418b,color:#43418b
-				role_39ad2981(["[role] display_some_facts"])
-				style role_39ad2981 fill:#43418b,color:#ffffff,stroke:#43418b
-					task_110062e7["[task] display_some_facts : ansible_architecture"]
-					style task_110062e7 stroke:#43418b,fill:#ffffff
-					role_39ad2981 --> |"1"| task_110062e7
-					linkStyle 29 stroke:#43418b,color:#43418b
-					task_05309d40["[task] display_some_facts : ansible_date_time"]
-					style task_05309d40 stroke:#43418b,fill:#ffffff
-					role_39ad2981 --> |"2"| task_05309d40
-					linkStyle 30 stroke:#43418b,color:#43418b
-					task_d8106118["[task] display_some_facts : Specific included task for Debian"]
-					style task_d8106118 stroke:#43418b,fill:#ffffff
-					role_39ad2981 --> |"3"| task_d8106118
-					linkStyle 31 stroke:#43418b,color:#43418b
-				%% End of the role '[role] display_some_facts'
-				%% Start of the role '[role] fake_role'
-				role_f611e648 --> |"4"| role_60085133
-				linkStyle 32 stroke:#43418b,color:#43418b
-				role_60085133(["[role] fake_role"])
-				style role_60085133 fill:#43418b,color:#ffffff,stroke:#43418b
-					task_aa202401["[task] fake_role : Debug 1"]
-					style task_aa202401 stroke:#43418b,fill:#ffffff
-					role_60085133 --> |"1"| task_aa202401
-					linkStyle 33 stroke:#43418b,color:#43418b
-					task_bb8335d6["[task] fake_role : Debug 2"]
-					style task_bb8335d6 stroke:#43418b,fill:#ffffff
-					role_60085133 --> |"2"| task_bb8335d6
-					linkStyle 34 stroke:#43418b,color:#43418b
-					task_7e0c8ed3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-					style task_7e0c8ed3 stroke:#43418b,fill:#ffffff
-					role_60085133 --> |"3"| task_7e0c8ed3
-					linkStyle 35 stroke:#43418b,color:#43418b
-				%% End of the role '[role] fake_role'
-			%% End of the role '[role] nested_include_role'
-			%% Start of the role '[role] display_some_facts'
-			play_4d3ee472 --> |"2"| role_ff23a4e9
-			linkStyle 36 stroke:#43418b,color:#43418b
-			role_ff23a4e9(["[role] display_some_facts"])
-			style role_ff23a4e9 fill:#43418b,color:#ffffff,stroke:#43418b
-				task_8fc8f4bc["[task] display_some_facts : ansible_architecture"]
-				style task_8fc8f4bc stroke:#43418b,fill:#ffffff
-				role_ff23a4e9 --> |"1"| task_8fc8f4bc
-				linkStyle 37 stroke:#43418b,color:#43418b
-				task_6a9bc407["[task] display_some_facts : ansible_date_time"]
-				style task_6a9bc407 stroke:#43418b,fill:#ffffff
-				role_ff23a4e9 --> |"2"| task_6a9bc407
-				linkStyle 38 stroke:#43418b,color:#43418b
-				task_b6121d94["[task] display_some_facts : Specific included task for Debian"]
-				style task_b6121d94 stroke:#43418b,fill:#ffffff
-				role_ff23a4e9 --> |"3"| task_b6121d94
-				linkStyle 39 stroke:#43418b,color:#43418b
-			%% End of the role '[role] display_some_facts'
-		%% End of the play 'Play: webserver (0)'
-	%% End of the playbook 'tests/fixtures/multi-plays.yml'
+%% Start of the playbook 'tests/fixtures/multi-plays.yml'
+    playbook_a27d9bec("tests/fixtures/multi-plays.yml")
+%% Start of the play 'Play: all (0)'
+    play_d6dd122d["Play: all (0)"]
+    style play_d6dd122d stroke:#ba1a12, fill:#ba1a12, color:#ffffff
+    playbook_a27d9bec -->|" 1 "| play_d6dd122d
+    linkStyle 0 stroke:#ba1a12, color:#ba1a12
+    pre_task_676cdcb1["[pre_task] Pretask"]
+    style pre_task_676cdcb1 stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 1 "| pre_task_676cdcb1
+    linkStyle 1 stroke:#ba1a12, color:#ba1a12
+    pre_task_44476583["[pre_task] Pretask 2"]
+    style pre_task_44476583 stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 2 "| pre_task_44476583
+    linkStyle 2 stroke:#ba1a12, color:#ba1a12
+%% Start of the role '[role] fake_role'
+    play_d6dd122d -->|" 3 "| role_f0c07194
+    linkStyle 3 stroke:#ba1a12, color:#ba1a12
+    role_f0c07194(["[role] fake_role"])
+    style role_f0c07194 fill:#ba1a12, color:#ffffff, stroke:#ba1a12
+    task_90876ffc["[task] fake_role : Debug 1"]
+    style task_90876ffc stroke:#ba1a12, fill:#ffffff
+    role_f0c07194 -->|" 1 [when: ansible_distribution == 'Debian'] "| task_90876ffc
+    linkStyle 4 stroke:#ba1a12, color:#ba1a12
+    task_bb701882["[task] fake_role : Debug 2"]
+    style task_bb701882 stroke:#ba1a12, fill:#ffffff
+    role_f0c07194 -->|" 2 [when: ansible_distribution == 'Debian'] "| task_bb701882
+    linkStyle 5 stroke:#ba1a12, color:#ba1a12
+    task_c00c5d61["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+    style task_c00c5d61 stroke:#ba1a12, fill:#ffffff
+    role_f0c07194 -->|" 3 [when: ansible_distribution == 'Debian'] "| task_c00c5d61
+    linkStyle 6 stroke:#ba1a12, color:#ba1a12
+%% End of the role '[role] fake_role'
+%% Start of the role '[role] display_some_facts'
+    play_d6dd122d -->|" 4 "| role_a168caef
+    linkStyle 7 stroke:#ba1a12, color:#ba1a12
+    role_a168caef(["[role] display_some_facts"])
+    style role_a168caef fill:#ba1a12, color:#ffffff, stroke:#ba1a12
+    task_737e2be9["[task] display_some_facts : ansible_architecture"]
+    style task_737e2be9 stroke:#ba1a12, fill:#ffffff
+    role_a168caef -->|" 1 "| task_737e2be9
+    linkStyle 8 stroke:#ba1a12, color:#ba1a12
+    task_61bbb3fb["[task] display_some_facts : ansible_date_time"]
+    style task_61bbb3fb stroke:#ba1a12, fill:#ffffff
+    role_a168caef -->|" 2 "| task_61bbb3fb
+    linkStyle 9 stroke:#ba1a12, color:#ba1a12
+    task_3b7308dc["[task] display_some_facts : Specific included task for Debian"]
+    style task_3b7308dc stroke:#ba1a12, fill:#ffffff
+    role_a168caef -->|" 3 "| task_3b7308dc
+    linkStyle 10 stroke:#ba1a12, color:#ba1a12
+%% End of the role '[role] display_some_facts'
+    task_c8b76065["[task] Add backport {{backport}}"]
+    style task_c8b76065 stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 5 "| task_c8b76065
+    linkStyle 11 stroke:#ba1a12, color:#ba1a12
+    task_f7cebcbb["[task] Install packages"]
+    style task_f7cebcbb stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 6 "| task_f7cebcbb
+    linkStyle 12 stroke:#ba1a12, color:#ba1a12
+    post_task_caafa665["[post_task] Posttask"]
+    style post_task_caafa665 stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 7 "| post_task_caafa665
+    linkStyle 13 stroke:#ba1a12, color:#ba1a12
+    post_task_b5ade468["[post_task] Posttask 2"]
+    style post_task_b5ade468 stroke:#ba1a12, fill:#ffffff
+    play_d6dd122d -->|" 8 "| post_task_b5ade468
+    linkStyle 14 stroke:#ba1a12, color:#ba1a12
+%% End of the play 'Play: all (0)'
+%% Start of the play 'Play: database (0)'
+    play_d780677e["Play: database (0)"]
+    style play_d780677e stroke:#686864, fill:#686864, color:#ffffff
+    playbook_a27d9bec -->|" 2 "| play_d780677e
+    linkStyle 15 stroke:#686864, color:#686864
+%% Start of the role '[role] fake_role'
+    play_d780677e -->|" 1 "| role_1e6bf323
+    linkStyle 16 stroke:#686864, color:#686864
+    role_1e6bf323(["[role] fake_role"])
+    style role_1e6bf323 fill:#686864, color:#ffffff, stroke:#686864
+    task_3cb17d25["[task] fake_role : Debug 1"]
+    style task_3cb17d25 stroke:#686864, fill:#ffffff
+    role_1e6bf323 -->|" 1 [when: ansible_distribution == 'Debian'] "| task_3cb17d25
+    linkStyle 17 stroke:#686864, color:#686864
+    task_1f6232f4["[task] fake_role : Debug 2"]
+    style task_1f6232f4 stroke:#686864, fill:#ffffff
+    role_1e6bf323 -->|" 2 [when: ansible_distribution == 'Debian'] "| task_1f6232f4
+    linkStyle 18 stroke:#686864, color:#686864
+    task_0361ffa3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+    style task_0361ffa3 stroke:#686864, fill:#ffffff
+    role_1e6bf323 -->|" 3 [when: ansible_distribution == 'Debian'] "| task_0361ffa3
+    linkStyle 19 stroke:#686864, color:#686864
+%% End of the role '[role] fake_role'
+%% Start of the role '[role] display_some_facts'
+    play_d780677e -->|" 2 "| role_a8b4b712
+    linkStyle 20 stroke:#686864, color:#686864
+    role_a8b4b712(["[role] display_some_facts"])
+    style role_a8b4b712 fill:#686864, color:#ffffff, stroke:#686864
+    task_c1d17653["[task] display_some_facts : ansible_architecture"]
+    style task_c1d17653 stroke:#686864, fill:#ffffff
+    role_a8b4b712 -->|" 1 "| task_c1d17653
+    linkStyle 21 stroke:#686864, color:#686864
+    task_8353a2ef["[task] display_some_facts : ansible_date_time"]
+    style task_8353a2ef stroke:#686864, fill:#ffffff
+    role_a8b4b712 -->|" 2 "| task_8353a2ef
+    linkStyle 22 stroke:#686864, color:#686864
+    task_d8141ffa["[task] display_some_facts : Specific included task for Debian"]
+    style task_d8141ffa stroke:#686864, fill:#ffffff
+    role_a8b4b712 -->|" 3 "| task_d8141ffa
+    linkStyle 23 stroke:#686864, color:#686864
+%% End of the role '[role] display_some_facts'
+%% End of the play 'Play: database (0)'
+%% Start of the play 'Play: webserver (0)'
+    play_4d3ee472["Play: webserver (0)"]
+    style play_4d3ee472 stroke:#43418b, fill:#43418b, color:#ffffff
+    playbook_a27d9bec -->|" 3 "| play_4d3ee472
+    linkStyle 24 stroke:#43418b, color:#43418b
+%% Start of the role '[role] nested_include_role'
+    play_4d3ee472 -->|" 1 "| role_f611e648
+    linkStyle 25 stroke:#43418b, color:#43418b
+    role_f611e648(["[role] nested_include_role"])
+    style role_f611e648 fill:#43418b, color:#ffffff, stroke:#43418b
+    task_8d2e4414["[task] nested_include_role : Ensure postgresql is at the latest version"]
+    style task_8d2e4414 stroke:#43418b, fill:#ffffff
+    role_f611e648 -->|" 1 "| task_8d2e4414
+    linkStyle 26 stroke:#43418b, color:#43418b
+    task_d1bc52f0["[task] nested_include_role : Ensure that postgresql is started"]
+    style task_d1bc52f0 stroke:#43418b, fill:#ffffff
+    role_f611e648 -->|" 2 "| task_d1bc52f0
+    linkStyle 27 stroke:#43418b, color:#43418b
+%% Start of the role '[role] display_some_facts'
+    role_f611e648 -->|" 3 [when: x is not defined] "| role_39ad2981
+    linkStyle 28 stroke:#43418b, color:#43418b
+    role_39ad2981(["[role] display_some_facts"])
+    style role_39ad2981 fill:#43418b, color:#ffffff, stroke:#43418b
+    task_110062e7["[task] display_some_facts : ansible_architecture"]
+    style task_110062e7 stroke:#43418b, fill:#ffffff
+    role_39ad2981 -->|" 1 "| task_110062e7
+    linkStyle 29 stroke:#43418b, color:#43418b
+    task_05309d40["[task] display_some_facts : ansible_date_time"]
+    style task_05309d40 stroke:#43418b, fill:#ffffff
+    role_39ad2981 -->|" 2 "| task_05309d40
+    linkStyle 30 stroke:#43418b, color:#43418b
+    task_d8106118["[task] display_some_facts : Specific included task for Debian"]
+    style task_d8106118 stroke:#43418b, fill:#ffffff
+    role_39ad2981 -->|" 3 "| task_d8106118
+    linkStyle 31 stroke:#43418b, color:#43418b
+%% End of the role '[role] display_some_facts'
+%% Start of the role '[role] fake_role'
+    role_f611e648 -->|" 4 "| role_60085133
+    linkStyle 32 stroke:#43418b, color:#43418b
+    role_60085133(["[role] fake_role"])
+    style role_60085133 fill:#43418b, color:#ffffff, stroke:#43418b
+    task_aa202401["[task] fake_role : Debug 1"]
+    style task_aa202401 stroke:#43418b, fill:#ffffff
+    role_60085133 -->|" 1 "| task_aa202401
+    linkStyle 33 stroke:#43418b, color:#43418b
+    task_bb8335d6["[task] fake_role : Debug 2"]
+    style task_bb8335d6 stroke:#43418b, fill:#ffffff
+    role_60085133 -->|" 2 "| task_bb8335d6
+    linkStyle 34 stroke:#43418b, color:#43418b
+    task_7e0c8ed3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+    style task_7e0c8ed3 stroke:#43418b, fill:#ffffff
+    role_60085133 -->|" 3 "| task_7e0c8ed3
+    linkStyle 35 stroke:#43418b, color:#43418b
+%% End of the role '[role] fake_role'
+%% End of the role '[role] nested_include_role'
+%% Start of the role '[role] display_some_facts'
+    play_4d3ee472 -->|" 2 "| role_ff23a4e9
+    linkStyle 36 stroke:#43418b, color:#43418b
+    role_ff23a4e9(["[role] display_some_facts"])
+    style role_ff23a4e9 fill:#43418b, color:#ffffff, stroke:#43418b
+    task_8fc8f4bc["[task] display_some_facts : ansible_architecture"]
+    style task_8fc8f4bc stroke:#43418b, fill:#ffffff
+    role_ff23a4e9 -->|" 1 "| task_8fc8f4bc
+    linkStyle 37 stroke:#43418b, color:#43418b
+    task_6a9bc407["[task] display_some_facts : ansible_date_time"]
+    style task_6a9bc407 stroke:#43418b, fill:#ffffff
+    role_ff23a4e9 -->|" 2 "| task_6a9bc407
+    linkStyle 38 stroke:#43418b, color:#43418b
+    task_b6121d94["[task] display_some_facts : Specific included task for Debian"]
+    style task_b6121d94 stroke:#43418b, fill:#ffffff
+    role_ff23a4e9 -->|" 3 "| task_b6121d94
+    linkStyle 39 stroke:#43418b, color:#43418b
+%% End of the role '[role] display_some_facts'
+%% End of the play 'Play: webserver (0)'
+%% End of the playbook 'tests/fixtures/multi-plays.yml'
 ```
 
 ```shell
@@ -422,7 +435,7 @@ options:
   --hide-plays-without-roles
                         Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as tasks are
                         considered (no import_role).
-  --include-role-tasks  Include the tasks of the roles in the graph. Applied when parsing the playbooks.
+  --include-role-tasks  Include the tasks of the roles in the graph.
   --only-roles          Only render the roles in the graph (ignoring the tasks).
   --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
                         The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to custom. You should provide a
@@ -488,7 +501,8 @@ More information [here](https://docs.ansible.com/ansible/latest/reference_append
   Always check the edge label to know the task order.
 - The label of the edges may overlap with each other. They are positioned so that they are as close as possible to
   the target nodes. If the same role is used in multiple plays or playbooks, the labels can overlap.
-- **Ansible Handlers**: The handlers are partially supported for the moment. Their position in the graph doesn't entirely
+- **Ansible Handlers**: The handlers are partially supported for the moment. Their position in the graph doesn't
+  entirely
   reflect their real order of execution in the playbook. They are displayed at the end of the play and roles, but they
   might be executed before that.
 - Looping on tasks and roles is not supported. The tasks using loop are displayed as a single task.

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ More information [here](https://docs.ansible.com/ansible/latest/reference_append
 - **Ansible Handlers**: The handlers are partially supported for the moment. Their position in the graph doesn't entirely
   reflect their real order of execution in the playbook. They are displayed at the end of the play and roles, but they
   might be executed before that.
-- Looping on tasks is not supported. The tasks using loop are displayed as a single task.
+- Looping on tasks and roles is not supported. The tasks using loop are displayed as a single task.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -130,191 +130,191 @@ title: Ansible Playbook Grapher
 ---
 %%{ init: { "flowchart": { "curve": "bumpX" } } }%%
 flowchart LR
-%% Start of the playbook 'tests/fixtures/multi-plays.yml'
-    playbook_a27d9bec("tests/fixtures/multi-plays.yml")
-%% Start of the play 'Play: all (0)'
-    play_d6dd122d["Play: all (0)"]
-    style play_d6dd122d stroke:#ba1a12, fill:#ba1a12, color:#ffffff
-    playbook_a27d9bec -->|" 1 "| play_d6dd122d
-    linkStyle 0 stroke:#ba1a12, color:#ba1a12
-    pre_task_676cdcb1["[pre_task] Pretask"]
-    style pre_task_676cdcb1 stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 1 "| pre_task_676cdcb1
-    linkStyle 1 stroke:#ba1a12, color:#ba1a12
-    pre_task_44476583["[pre_task] Pretask 2"]
-    style pre_task_44476583 stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 2 "| pre_task_44476583
-    linkStyle 2 stroke:#ba1a12, color:#ba1a12
-%% Start of the role '[role] fake_role'
-    play_d6dd122d -->|" 3 "| role_f0c07194
-    linkStyle 3 stroke:#ba1a12, color:#ba1a12
-    role_f0c07194(["[role] fake_role"])
-    style role_f0c07194 fill:#ba1a12, color:#ffffff, stroke:#ba1a12
-    task_90876ffc["[task] fake_role : Debug 1"]
-    style task_90876ffc stroke:#ba1a12, fill:#ffffff
-    role_f0c07194 -->|" 1 [when: ansible_distribution == 'Debian'] "| task_90876ffc
-    linkStyle 4 stroke:#ba1a12, color:#ba1a12
-    task_bb701882["[task] fake_role : Debug 2"]
-    style task_bb701882 stroke:#ba1a12, fill:#ffffff
-    role_f0c07194 -->|" 2 [when: ansible_distribution == 'Debian'] "| task_bb701882
-    linkStyle 5 stroke:#ba1a12, color:#ba1a12
-    task_c00c5d61["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-    style task_c00c5d61 stroke:#ba1a12, fill:#ffffff
-    role_f0c07194 -->|" 3 [when: ansible_distribution == 'Debian'] "| task_c00c5d61
-    linkStyle 6 stroke:#ba1a12, color:#ba1a12
-%% End of the role '[role] fake_role'
-%% Start of the role '[role] display_some_facts'
-    play_d6dd122d -->|" 4 "| role_a168caef
-    linkStyle 7 stroke:#ba1a12, color:#ba1a12
-    role_a168caef(["[role] display_some_facts"])
-    style role_a168caef fill:#ba1a12, color:#ffffff, stroke:#ba1a12
-    task_737e2be9["[task] display_some_facts : ansible_architecture"]
-    style task_737e2be9 stroke:#ba1a12, fill:#ffffff
-    role_a168caef -->|" 1 "| task_737e2be9
-    linkStyle 8 stroke:#ba1a12, color:#ba1a12
-    task_61bbb3fb["[task] display_some_facts : ansible_date_time"]
-    style task_61bbb3fb stroke:#ba1a12, fill:#ffffff
-    role_a168caef -->|" 2 "| task_61bbb3fb
-    linkStyle 9 stroke:#ba1a12, color:#ba1a12
-    task_3b7308dc["[task] display_some_facts : Specific included task for Debian"]
-    style task_3b7308dc stroke:#ba1a12, fill:#ffffff
-    role_a168caef -->|" 3 "| task_3b7308dc
-    linkStyle 10 stroke:#ba1a12, color:#ba1a12
-%% End of the role '[role] display_some_facts'
-    task_c8b76065["[task] Add backport {{backport}}"]
-    style task_c8b76065 stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 5 "| task_c8b76065
-    linkStyle 11 stroke:#ba1a12, color:#ba1a12
-    task_f7cebcbb["[task] Install packages"]
-    style task_f7cebcbb stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 6 "| task_f7cebcbb
-    linkStyle 12 stroke:#ba1a12, color:#ba1a12
-    post_task_caafa665["[post_task] Posttask"]
-    style post_task_caafa665 stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 7 "| post_task_caafa665
-    linkStyle 13 stroke:#ba1a12, color:#ba1a12
-    post_task_b5ade468["[post_task] Posttask 2"]
-    style post_task_b5ade468 stroke:#ba1a12, fill:#ffffff
-    play_d6dd122d -->|" 8 "| post_task_b5ade468
-    linkStyle 14 stroke:#ba1a12, color:#ba1a12
-%% End of the play 'Play: all (0)'
-%% Start of the play 'Play: database (0)'
-    play_d780677e["Play: database (0)"]
-    style play_d780677e stroke:#686864, fill:#686864, color:#ffffff
-    playbook_a27d9bec -->|" 2 "| play_d780677e
-    linkStyle 15 stroke:#686864, color:#686864
-%% Start of the role '[role] fake_role'
-    play_d780677e -->|" 1 "| role_1e6bf323
-    linkStyle 16 stroke:#686864, color:#686864
-    role_1e6bf323(["[role] fake_role"])
-    style role_1e6bf323 fill:#686864, color:#ffffff, stroke:#686864
-    task_3cb17d25["[task] fake_role : Debug 1"]
-    style task_3cb17d25 stroke:#686864, fill:#ffffff
-    role_1e6bf323 -->|" 1 [when: ansible_distribution == 'Debian'] "| task_3cb17d25
-    linkStyle 17 stroke:#686864, color:#686864
-    task_1f6232f4["[task] fake_role : Debug 2"]
-    style task_1f6232f4 stroke:#686864, fill:#ffffff
-    role_1e6bf323 -->|" 2 [when: ansible_distribution == 'Debian'] "| task_1f6232f4
-    linkStyle 18 stroke:#686864, color:#686864
-    task_0361ffa3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-    style task_0361ffa3 stroke:#686864, fill:#ffffff
-    role_1e6bf323 -->|" 3 [when: ansible_distribution == 'Debian'] "| task_0361ffa3
-    linkStyle 19 stroke:#686864, color:#686864
-%% End of the role '[role] fake_role'
-%% Start of the role '[role] display_some_facts'
-    play_d780677e -->|" 2 "| role_a8b4b712
-    linkStyle 20 stroke:#686864, color:#686864
-    role_a8b4b712(["[role] display_some_facts"])
-    style role_a8b4b712 fill:#686864, color:#ffffff, stroke:#686864
-    task_c1d17653["[task] display_some_facts : ansible_architecture"]
-    style task_c1d17653 stroke:#686864, fill:#ffffff
-    role_a8b4b712 -->|" 1 "| task_c1d17653
-    linkStyle 21 stroke:#686864, color:#686864
-    task_8353a2ef["[task] display_some_facts : ansible_date_time"]
-    style task_8353a2ef stroke:#686864, fill:#ffffff
-    role_a8b4b712 -->|" 2 "| task_8353a2ef
-    linkStyle 22 stroke:#686864, color:#686864
-    task_d8141ffa["[task] display_some_facts : Specific included task for Debian"]
-    style task_d8141ffa stroke:#686864, fill:#ffffff
-    role_a8b4b712 -->|" 3 "| task_d8141ffa
-    linkStyle 23 stroke:#686864, color:#686864
-%% End of the role '[role] display_some_facts'
-%% End of the play 'Play: database (0)'
-%% Start of the play 'Play: webserver (0)'
-    play_4d3ee472["Play: webserver (0)"]
-    style play_4d3ee472 stroke:#43418b, fill:#43418b, color:#ffffff
-    playbook_a27d9bec -->|" 3 "| play_4d3ee472
-    linkStyle 24 stroke:#43418b, color:#43418b
-%% Start of the role '[role] nested_include_role'
-    play_4d3ee472 -->|" 1 "| role_f611e648
-    linkStyle 25 stroke:#43418b, color:#43418b
-    role_f611e648(["[role] nested_include_role"])
-    style role_f611e648 fill:#43418b, color:#ffffff, stroke:#43418b
-    task_8d2e4414["[task] nested_include_role : Ensure postgresql is at the latest version"]
-    style task_8d2e4414 stroke:#43418b, fill:#ffffff
-    role_f611e648 -->|" 1 "| task_8d2e4414
-    linkStyle 26 stroke:#43418b, color:#43418b
-    task_d1bc52f0["[task] nested_include_role : Ensure that postgresql is started"]
-    style task_d1bc52f0 stroke:#43418b, fill:#ffffff
-    role_f611e648 -->|" 2 "| task_d1bc52f0
-    linkStyle 27 stroke:#43418b, color:#43418b
-%% Start of the role '[role] display_some_facts'
-    role_f611e648 -->|" 3 [when: x is not defined] "| role_39ad2981
-    linkStyle 28 stroke:#43418b, color:#43418b
-    role_39ad2981(["[role] display_some_facts"])
-    style role_39ad2981 fill:#43418b, color:#ffffff, stroke:#43418b
-    task_110062e7["[task] display_some_facts : ansible_architecture"]
-    style task_110062e7 stroke:#43418b, fill:#ffffff
-    role_39ad2981 -->|" 1 "| task_110062e7
-    linkStyle 29 stroke:#43418b, color:#43418b
-    task_05309d40["[task] display_some_facts : ansible_date_time"]
-    style task_05309d40 stroke:#43418b, fill:#ffffff
-    role_39ad2981 -->|" 2 "| task_05309d40
-    linkStyle 30 stroke:#43418b, color:#43418b
-    task_d8106118["[task] display_some_facts : Specific included task for Debian"]
-    style task_d8106118 stroke:#43418b, fill:#ffffff
-    role_39ad2981 -->|" 3 "| task_d8106118
-    linkStyle 31 stroke:#43418b, color:#43418b
-%% End of the role '[role] display_some_facts'
-%% Start of the role '[role] fake_role'
-    role_f611e648 -->|" 4 "| role_60085133
-    linkStyle 32 stroke:#43418b, color:#43418b
-    role_60085133(["[role] fake_role"])
-    style role_60085133 fill:#43418b, color:#ffffff, stroke:#43418b
-    task_aa202401["[task] fake_role : Debug 1"]
-    style task_aa202401 stroke:#43418b, fill:#ffffff
-    role_60085133 -->|" 1 "| task_aa202401
-    linkStyle 33 stroke:#43418b, color:#43418b
-    task_bb8335d6["[task] fake_role : Debug 2"]
-    style task_bb8335d6 stroke:#43418b, fill:#ffffff
-    role_60085133 -->|" 2 "| task_bb8335d6
-    linkStyle 34 stroke:#43418b, color:#43418b
-    task_7e0c8ed3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
-    style task_7e0c8ed3 stroke:#43418b, fill:#ffffff
-    role_60085133 -->|" 3 "| task_7e0c8ed3
-    linkStyle 35 stroke:#43418b, color:#43418b
-%% End of the role '[role] fake_role'
-%% End of the role '[role] nested_include_role'
-%% Start of the role '[role] display_some_facts'
-    play_4d3ee472 -->|" 2 "| role_ff23a4e9
-    linkStyle 36 stroke:#43418b, color:#43418b
-    role_ff23a4e9(["[role] display_some_facts"])
-    style role_ff23a4e9 fill:#43418b, color:#ffffff, stroke:#43418b
-    task_8fc8f4bc["[task] display_some_facts : ansible_architecture"]
-    style task_8fc8f4bc stroke:#43418b, fill:#ffffff
-    role_ff23a4e9 -->|" 1 "| task_8fc8f4bc
-    linkStyle 37 stroke:#43418b, color:#43418b
-    task_6a9bc407["[task] display_some_facts : ansible_date_time"]
-    style task_6a9bc407 stroke:#43418b, fill:#ffffff
-    role_ff23a4e9 -->|" 2 "| task_6a9bc407
-    linkStyle 38 stroke:#43418b, color:#43418b
-    task_b6121d94["[task] display_some_facts : Specific included task for Debian"]
-    style task_b6121d94 stroke:#43418b, fill:#ffffff
-    role_ff23a4e9 -->|" 3 "| task_b6121d94
-    linkStyle 39 stroke:#43418b, color:#43418b
-%% End of the role '[role] display_some_facts'
-%% End of the play 'Play: webserver (0)'
-%% End of the playbook 'tests/fixtures/multi-plays.yml'
+	%% Start of the playbook 'tests/fixtures/multi-plays.yml'
+	playbook_a27d9bec("tests/fixtures/multi-plays.yml")
+		%% Start of the play 'Play: all (0)'
+		play_d6dd122d["Play: all (0)"]
+		style play_d6dd122d stroke:#ba1a12,fill:#ba1a12,color:#ffffff
+		playbook_a27d9bec --> |"1"| play_d6dd122d
+		linkStyle 0 stroke:#ba1a12,color:#ba1a12
+			pre_task_676cdcb1["[pre_task] Pretask"]
+			style pre_task_676cdcb1 stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"1"| pre_task_676cdcb1
+			linkStyle 1 stroke:#ba1a12,color:#ba1a12
+			pre_task_44476583["[pre_task] Pretask 2"]
+			style pre_task_44476583 stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"2"| pre_task_44476583
+			linkStyle 2 stroke:#ba1a12,color:#ba1a12
+			%% Start of the role '[role] fake_role'
+			play_d6dd122d --> |"3"| role_f0c07194
+			linkStyle 3 stroke:#ba1a12,color:#ba1a12
+			role_f0c07194(["[role] fake_role"])
+			style role_f0c07194 fill:#ba1a12,color:#ffffff,stroke:#ba1a12
+				task_90876ffc["[task] fake_role : Debug 1"]
+				style task_90876ffc stroke:#ba1a12,fill:#ffffff
+				role_f0c07194 --> |"1 [when: ansible_distribution == 'Debian']"| task_90876ffc
+				linkStyle 4 stroke:#ba1a12,color:#ba1a12
+				task_bb701882["[task] fake_role : Debug 2"]
+				style task_bb701882 stroke:#ba1a12,fill:#ffffff
+				role_f0c07194 --> |"2 [when: ansible_distribution == 'Debian']"| task_bb701882
+				linkStyle 5 stroke:#ba1a12,color:#ba1a12
+				task_c00c5d61["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+				style task_c00c5d61 stroke:#ba1a12,fill:#ffffff
+				role_f0c07194 --> |"3 [when: ansible_distribution == 'Debian']"| task_c00c5d61
+				linkStyle 6 stroke:#ba1a12,color:#ba1a12
+			%% End of the role '[role] fake_role'
+			%% Start of the role '[role] display_some_facts'
+			play_d6dd122d --> |"4"| role_a168caef
+			linkStyle 7 stroke:#ba1a12,color:#ba1a12
+			role_a168caef(["[role] display_some_facts"])
+			style role_a168caef fill:#ba1a12,color:#ffffff,stroke:#ba1a12
+				task_737e2be9["[task] display_some_facts : ansible_architecture"]
+				style task_737e2be9 stroke:#ba1a12,fill:#ffffff
+				role_a168caef --> |"1"| task_737e2be9
+				linkStyle 8 stroke:#ba1a12,color:#ba1a12
+				task_61bbb3fb["[task] display_some_facts : ansible_date_time"]
+				style task_61bbb3fb stroke:#ba1a12,fill:#ffffff
+				role_a168caef --> |"2"| task_61bbb3fb
+				linkStyle 9 stroke:#ba1a12,color:#ba1a12
+				task_3b7308dc["[task] display_some_facts : Specific included task for Debian"]
+				style task_3b7308dc stroke:#ba1a12,fill:#ffffff
+				role_a168caef --> |"3"| task_3b7308dc
+				linkStyle 10 stroke:#ba1a12,color:#ba1a12
+			%% End of the role '[role] display_some_facts'
+			task_c8b76065["[task] Add backport {{backport}}"]
+			style task_c8b76065 stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"5"| task_c8b76065
+			linkStyle 11 stroke:#ba1a12,color:#ba1a12
+			task_f7cebcbb["[task] Install packages"]
+			style task_f7cebcbb stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"6"| task_f7cebcbb
+			linkStyle 12 stroke:#ba1a12,color:#ba1a12
+			post_task_caafa665["[post_task] Posttask"]
+			style post_task_caafa665 stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"7"| post_task_caafa665
+			linkStyle 13 stroke:#ba1a12,color:#ba1a12
+			post_task_b5ade468["[post_task] Posttask 2"]
+			style post_task_b5ade468 stroke:#ba1a12,fill:#ffffff
+			play_d6dd122d --> |"8"| post_task_b5ade468
+			linkStyle 14 stroke:#ba1a12,color:#ba1a12
+		%% End of the play 'Play: all (0)'
+		%% Start of the play 'Play: database (0)'
+		play_d780677e["Play: database (0)"]
+		style play_d780677e stroke:#686864,fill:#686864,color:#ffffff
+		playbook_a27d9bec --> |"2"| play_d780677e
+		linkStyle 15 stroke:#686864,color:#686864
+			%% Start of the role '[role] fake_role'
+			play_d780677e --> |"1"| role_1e6bf323
+			linkStyle 16 stroke:#686864,color:#686864
+			role_1e6bf323(["[role] fake_role"])
+			style role_1e6bf323 fill:#686864,color:#ffffff,stroke:#686864
+				task_3cb17d25["[task] fake_role : Debug 1"]
+				style task_3cb17d25 stroke:#686864,fill:#ffffff
+				role_1e6bf323 --> |"1 [when: ansible_distribution == 'Debian']"| task_3cb17d25
+				linkStyle 17 stroke:#686864,color:#686864
+				task_1f6232f4["[task] fake_role : Debug 2"]
+				style task_1f6232f4 stroke:#686864,fill:#ffffff
+				role_1e6bf323 --> |"2 [when: ansible_distribution == 'Debian']"| task_1f6232f4
+				linkStyle 18 stroke:#686864,color:#686864
+				task_0361ffa3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+				style task_0361ffa3 stroke:#686864,fill:#ffffff
+				role_1e6bf323 --> |"3 [when: ansible_distribution == 'Debian']"| task_0361ffa3
+				linkStyle 19 stroke:#686864,color:#686864
+			%% End of the role '[role] fake_role'
+			%% Start of the role '[role] display_some_facts'
+			play_d780677e --> |"2"| role_a8b4b712
+			linkStyle 20 stroke:#686864,color:#686864
+			role_a8b4b712(["[role] display_some_facts"])
+			style role_a8b4b712 fill:#686864,color:#ffffff,stroke:#686864
+				task_c1d17653["[task] display_some_facts : ansible_architecture"]
+				style task_c1d17653 stroke:#686864,fill:#ffffff
+				role_a8b4b712 --> |"1"| task_c1d17653
+				linkStyle 21 stroke:#686864,color:#686864
+				task_8353a2ef["[task] display_some_facts : ansible_date_time"]
+				style task_8353a2ef stroke:#686864,fill:#ffffff
+				role_a8b4b712 --> |"2"| task_8353a2ef
+				linkStyle 22 stroke:#686864,color:#686864
+				task_d8141ffa["[task] display_some_facts : Specific included task for Debian"]
+				style task_d8141ffa stroke:#686864,fill:#ffffff
+				role_a8b4b712 --> |"3"| task_d8141ffa
+				linkStyle 23 stroke:#686864,color:#686864
+			%% End of the role '[role] display_some_facts'
+		%% End of the play 'Play: database (0)'
+		%% Start of the play 'Play: webserver (0)'
+		play_4d3ee472["Play: webserver (0)"]
+		style play_4d3ee472 stroke:#43418b,fill:#43418b,color:#ffffff
+		playbook_a27d9bec --> |"3"| play_4d3ee472
+		linkStyle 24 stroke:#43418b,color:#43418b
+			%% Start of the role '[role] nested_include_role'
+			play_4d3ee472 --> |"1"| role_f611e648
+			linkStyle 25 stroke:#43418b,color:#43418b
+			role_f611e648(["[role] nested_include_role"])
+			style role_f611e648 fill:#43418b,color:#ffffff,stroke:#43418b
+				task_8d2e4414["[task] nested_include_role : Ensure postgresql is at the latest version"]
+				style task_8d2e4414 stroke:#43418b,fill:#ffffff
+				role_f611e648 --> |"1"| task_8d2e4414
+				linkStyle 26 stroke:#43418b,color:#43418b
+				task_d1bc52f0["[task] nested_include_role : Ensure that postgresql is started"]
+				style task_d1bc52f0 stroke:#43418b,fill:#ffffff
+				role_f611e648 --> |"2"| task_d1bc52f0
+				linkStyle 27 stroke:#43418b,color:#43418b
+				%% Start of the role '[role] display_some_facts'
+				role_f611e648 --> |"3 [when: x is not defined]"| role_39ad2981
+				linkStyle 28 stroke:#43418b,color:#43418b
+				role_39ad2981(["[role] display_some_facts"])
+				style role_39ad2981 fill:#43418b,color:#ffffff,stroke:#43418b
+					task_110062e7["[task] display_some_facts : ansible_architecture"]
+					style task_110062e7 stroke:#43418b,fill:#ffffff
+					role_39ad2981 --> |"1"| task_110062e7
+					linkStyle 29 stroke:#43418b,color:#43418b
+					task_05309d40["[task] display_some_facts : ansible_date_time"]
+					style task_05309d40 stroke:#43418b,fill:#ffffff
+					role_39ad2981 --> |"2"| task_05309d40
+					linkStyle 30 stroke:#43418b,color:#43418b
+					task_d8106118["[task] display_some_facts : Specific included task for Debian"]
+					style task_d8106118 stroke:#43418b,fill:#ffffff
+					role_39ad2981 --> |"3"| task_d8106118
+					linkStyle 31 stroke:#43418b,color:#43418b
+				%% End of the role '[role] display_some_facts'
+				%% Start of the role '[role] fake_role'
+				role_f611e648 --> |"4"| role_60085133
+				linkStyle 32 stroke:#43418b,color:#43418b
+				role_60085133(["[role] fake_role"])
+				style role_60085133 fill:#43418b,color:#ffffff,stroke:#43418b
+					task_aa202401["[task] fake_role : Debug 1"]
+					style task_aa202401 stroke:#43418b,fill:#ffffff
+					role_60085133 --> |"1"| task_aa202401
+					linkStyle 33 stroke:#43418b,color:#43418b
+					task_bb8335d6["[task] fake_role : Debug 2"]
+					style task_bb8335d6 stroke:#43418b,fill:#ffffff
+					role_60085133 --> |"2"| task_bb8335d6
+					linkStyle 34 stroke:#43418b,color:#43418b
+					task_7e0c8ed3["[task] fake_role : Debug 3 with double quote &#34;here&#34; in the name"]
+					style task_7e0c8ed3 stroke:#43418b,fill:#ffffff
+					role_60085133 --> |"3"| task_7e0c8ed3
+					linkStyle 35 stroke:#43418b,color:#43418b
+				%% End of the role '[role] fake_role'
+			%% End of the role '[role] nested_include_role'
+			%% Start of the role '[role] display_some_facts'
+			play_4d3ee472 --> |"2"| role_ff23a4e9
+			linkStyle 36 stroke:#43418b,color:#43418b
+			role_ff23a4e9(["[role] display_some_facts"])
+			style role_ff23a4e9 fill:#43418b,color:#ffffff,stroke:#43418b
+				task_8fc8f4bc["[task] display_some_facts : ansible_architecture"]
+				style task_8fc8f4bc stroke:#43418b,fill:#ffffff
+				role_ff23a4e9 --> |"1"| task_8fc8f4bc
+				linkStyle 37 stroke:#43418b,color:#43418b
+				task_6a9bc407["[task] display_some_facts : ansible_date_time"]
+				style task_6a9bc407 stroke:#43418b,fill:#ffffff
+				role_ff23a4e9 --> |"2"| task_6a9bc407
+				linkStyle 38 stroke:#43418b,color:#43418b
+				task_b6121d94["[task] display_some_facts : Specific included task for Debian"]
+				style task_b6121d94 stroke:#43418b,fill:#ffffff
+				role_ff23a4e9 --> |"3"| task_b6121d94
+				linkStyle 39 stroke:#43418b,color:#43418b
+			%% End of the role '[role] display_some_facts'
+		%% End of the play 'Play: webserver (0)'
+	%% End of the playbook 'tests/fixtures/multi-plays.yml'
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ options:
                         Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as tasks are
                         considered (no import_role).
   --include-role-tasks  Include the tasks of the roles in the graph. Applied when parsing the playbooks.
-  --only-roles          Only display the roles in the graph (ignoring the tasks)
+  --only-roles          Only render the roles in the graph (ignoring the tasks).
   --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
                         The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to custom. You should provide a
                         JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to open folders (roles) inside the browser and files

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -79,7 +79,6 @@ class PlaybookGrapherCLI(CLI):
             skip_tags=self.options.skip_tags,
             group_roles_by_name=self.options.group_roles_by_name,
             exclude_roles=self.options.exclude_roles,
-            only_roles=self.options.only_roles,
         )
 
         match self.options.renderer:
@@ -99,6 +98,7 @@ class PlaybookGrapherCLI(CLI):
                     include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
                     save_dot_file=self.options.save_dot_file,
+                    ony_roles=self.options.only_roles,
                 )
 
             case "mermaid-flowchart":
@@ -118,6 +118,7 @@ class PlaybookGrapherCLI(CLI):
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
                     include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
+                    ony_roles=self.options.only_roles,
                 )
 
             case "json":
@@ -132,6 +133,7 @@ class PlaybookGrapherCLI(CLI):
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
                     include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
+                    ony_roles=self.options.only_roles,
                 )
 
             case _:

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -90,7 +90,7 @@ class PlaybookGrapherCLI(CLI):
                 p.exclude_plays_without_roles()
 
             if self.options.only_roles:
-                p.exclude_tasks()
+                p.exclude_tasks_node()
 
             p.calculate_indices()
 

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -75,7 +75,6 @@ class PlaybookGrapherCLI(CLI):
         self.resolve_playbooks_paths()
         grapher = Grapher(self._playbook_paths_mapping)
         playbook_nodes, roles_usage = grapher.parse(
-            include_role_tasks=self.options.include_role_tasks,
             tags=self.options.tags,
             skip_tags=self.options.skip_tags,
             group_roles_by_name=self.options.group_roles_by_name,
@@ -97,6 +96,7 @@ class PlaybookGrapherCLI(CLI):
                     view=self.options.view,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
                     save_dot_file=self.options.save_dot_file,
                 )
@@ -116,6 +116,7 @@ class PlaybookGrapherCLI(CLI):
                     orientation=self.options.renderer_mermaid_orientation,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
                 )
 
@@ -129,6 +130,7 @@ class PlaybookGrapherCLI(CLI):
                     view=self.options.view,
                     hide_empty_plays=self.options.hide_empty_plays,
                     hide_plays_without_roles=self.options.hide_plays_without_roles,
+                    include_role_tasks=self.options.include_role_tasks,
                     show_handlers=self.options.show_handlers,
                 )
 
@@ -197,12 +199,13 @@ class PlaybookGrapherCLI(CLI):
             help="Specify inventory host path or comma separated host list.",
         )
 
+        # TODO: Rename this in the next major version for consistency with the other options: --show-role-tasks ?
         self.parser.add_argument(
             "--include-role-tasks",
             dest="include_role_tasks",
             action="store_true",
             default=False,
-            help="Include the tasks of the roles in the graph. Applied when parsing the playbooks.",
+            help="Include the tasks of the roles in the graph. Default: %(default)s",
         )
 
         self.parser.add_argument(

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -81,6 +81,13 @@ class PlaybookGrapherCLI(CLI):
             exclude_roles=self.options.exclude_roles,
         )
 
+        for p in playbook_nodes:
+            if self.options.hide_empty_plays:
+                p.exclude_empty_plays()
+
+            if self.options.hide_plays_without_roles:
+                p.exclude_plays_without_roles()
+
         match self.options.renderer:
             case "graphviz":
                 renderer = GraphvizRenderer(
@@ -92,13 +99,11 @@ class PlaybookGrapherCLI(CLI):
                     open_protocol_custom_formats=self.options.open_protocol_custom_formats,
                     output_filename=self.options.output_filename,
                     title=self.options.title,
-                    view=self.options.view,
-                    hide_empty_plays=self.options.hide_empty_plays,
-                    hide_plays_without_roles=self.options.hide_plays_without_roles,
                     include_role_tasks=self.options.include_role_tasks,
+                    view=self.options.view,
                     show_handlers=self.options.show_handlers,
-                    save_dot_file=self.options.save_dot_file,
                     ony_roles=self.options.only_roles,
+                    save_dot_file=self.options.save_dot_file,
                 )
 
             case "mermaid-flowchart":
@@ -111,14 +116,12 @@ class PlaybookGrapherCLI(CLI):
                     open_protocol_custom_formats=self.options.open_protocol_custom_formats,
                     output_filename=self.options.output_filename,
                     title=self.options.title,
-                    view=self.options.view,
-                    directive=self.options.renderer_mermaid_directive,
-                    orientation=self.options.renderer_mermaid_orientation,
-                    hide_empty_plays=self.options.hide_empty_plays,
-                    hide_plays_without_roles=self.options.hide_plays_without_roles,
                     include_role_tasks=self.options.include_role_tasks,
+                    view=self.options.view,
                     show_handlers=self.options.show_handlers,
                     ony_roles=self.options.only_roles,
+                    directive=self.options.renderer_mermaid_directive,
+                    orientation=self.options.renderer_mermaid_orientation,
                 )
 
             case "json":
@@ -128,10 +131,8 @@ class PlaybookGrapherCLI(CLI):
                     open_protocol_custom_formats=self.options.open_protocol_custom_formats,
                     output_filename=self.options.output_filename,
                     title=self.options.title,
-                    view=self.options.view,
-                    hide_empty_plays=self.options.hide_empty_plays,
-                    hide_plays_without_roles=self.options.hide_plays_without_roles,
                     include_role_tasks=self.options.include_role_tasks,
+                    view=self.options.view,
                     show_handlers=self.options.show_handlers,
                     ony_roles=self.options.only_roles,
                 )

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -31,6 +31,7 @@ from ansible.utils.collection_loader._collection_finder import (
 from ansible.utils.display import Display
 
 from ansibleplaybookgrapher import __prog__, __version__
+from ansibleplaybookgrapher.graph_model import TaskNode
 from ansibleplaybookgrapher.grapher import Grapher
 from ansibleplaybookgrapher.renderer import OPEN_PROTOCOL_HANDLERS
 from ansibleplaybookgrapher.renderer.graphviz import GraphvizRenderer
@@ -87,6 +88,8 @@ class PlaybookGrapherCLI(CLI):
 
             if self.options.hide_plays_without_roles:
                 p.exclude_plays_without_roles()
+
+            p.calculate_indices()
 
         match self.options.renderer:
             case "graphviz":

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -89,6 +89,9 @@ class PlaybookGrapherCLI(CLI):
             if self.options.hide_plays_without_roles:
                 p.exclude_plays_without_roles()
 
+            if self.options.only_roles:
+                p.exclude_tasks()
+
             p.calculate_indices()
 
         match self.options.renderer:
@@ -105,7 +108,7 @@ class PlaybookGrapherCLI(CLI):
                     include_role_tasks=self.options.include_role_tasks,
                     view=self.options.view,
                     show_handlers=self.options.show_handlers,
-                    ony_roles=self.options.only_roles,
+                    only_roles=self.options.only_roles,
                     save_dot_file=self.options.save_dot_file,
                 )
 
@@ -122,7 +125,7 @@ class PlaybookGrapherCLI(CLI):
                     include_role_tasks=self.options.include_role_tasks,
                     view=self.options.view,
                     show_handlers=self.options.show_handlers,
-                    ony_roles=self.options.only_roles,
+                    only_roles=self.options.only_roles,
                     directive=self.options.renderer_mermaid_directive,
                     orientation=self.options.renderer_mermaid_orientation,
                 )
@@ -137,7 +140,7 @@ class PlaybookGrapherCLI(CLI):
                     include_role_tasks=self.options.include_role_tasks,
                     view=self.options.view,
                     show_handlers=self.options.show_handlers,
-                    ony_roles=self.options.only_roles,
+                    only_roles=self.options.only_roles,
                 )
 
             case _:
@@ -194,7 +197,7 @@ class PlaybookGrapherCLI(CLI):
             "--only-roles",
             dest="only_roles",
             action="store_true",
-            help="Only display the roles in the graph (ignoring the tasks)",
+            help="Only render the roles in the graph (ignoring the tasks)",
         )
 
         self.parser.add_argument(

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -392,18 +392,18 @@ class PlaybookNode(CompositeNode):
 
     def plays(
         self,
-        exclude_empty: bool = False,
+        exclude_empty_plays: bool = False,
         exclude_without_roles: bool = False,
     ) -> list["PlayNode"]:
         """Return the list of plays.
 
-        :param exclude_empty: Whether to exclude the empty plays from the result or not
+        :param exclude_empty_plays: Whether to exclude the empty plays from the result or not
         :param exclude_without_roles: Whether to exclude the plays that do not have roles
         :return:
         """
         plays = self.get_nodes("plays")
 
-        if exclude_empty:
+        if exclude_empty_plays:
             plays = [play for play in plays if not play.is_empty()]
 
         if exclude_without_roles:
@@ -452,7 +452,7 @@ class PlaybookNode(CompositeNode):
         )
 
         for play in self.plays(
-            exclude_empty=exclude_empty_plays,
+            exclude_empty_plays=exclude_empty_plays,
             exclude_without_roles=exclude_plays_without_roles,
         ):
             new_playbook.add_node(
@@ -482,7 +482,7 @@ class PlaybookNode(CompositeNode):
 
         # We need to explicitly get the plays here to exclude the ones we don't need
         for play in self.plays(
-            exclude_empty=exclude_empty_plays,
+            exclude_empty_plays=exclude_empty_plays,
             exclude_without_roles=exclude_plays_without_roles,
         ):
             playbook_dict["plays"].append(

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -211,7 +211,7 @@ class CompositeNode(Node):
         )
         self.supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition: plays, tasks, roles...
-        self._compositions = defaultdict(list)  # type: dict[str, list]
+        self.compositions = defaultdict(list)  # type: dict[str, list]
 
     def _check_target_composition(self, target_composition: str) -> None:
         """Check if the target composition is supported.
@@ -233,7 +233,7 @@ class CompositeNode(Node):
         :return:
         """
         self._check_target_composition(target_composition)
-        self._compositions[target_composition].append(node)
+        self.compositions[target_composition].append(node)
 
     def remove_node(self, target_composition: str, node: Node) -> None:
         """Remove a node from the target composition.
@@ -243,7 +243,7 @@ class CompositeNode(Node):
         :return:
         """
         self._check_target_composition(target_composition)
-        self._compositions[target_composition].remove(node)
+        self.compositions[target_composition].remove(node)
 
     def calculate_indices(self):
         """
@@ -252,7 +252,7 @@ class CompositeNode(Node):
         """
         current_index = 1
         for comp_type in self.supported_compositions:
-            for node in self._compositions[comp_type]:
+            for node in self.compositions[comp_type]:
                 node.index = current_index
                 current_index += 1
 
@@ -266,7 +266,7 @@ class CompositeNode(Node):
         :return: A list of the nodes.
         """
         self._check_target_composition(target_composition)
-        return self._compositions[target_composition]
+        return self.compositions[target_composition]
 
     def get_all_tasks(self) -> list["TaskNode"]:
         """Return all the TaskNode inside this composite node.
@@ -292,7 +292,7 @@ class CompositeNode(Node):
         :param acc: The accumulator
         :return:
         """
-        for _, nodes in self._compositions.items():
+        for _, nodes in self.compositions.items():
             for node in nodes:
                 if isinstance(node, node_type):
                     acc.append(node)
@@ -314,7 +314,7 @@ class CompositeNode(Node):
 
         :return:
         """
-        for nodes in self._compositions.values():
+        for nodes in self.compositions.values():
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     node._get_all_links(links)
@@ -326,12 +326,12 @@ class CompositeNode(Node):
         A composite node is considered empty if all its compositions are empty.
         :return:
         """
-        for nodes in self._compositions.values():
+        for nodes in self.compositions.values():
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     return node.is_empty()
 
-        return all(len(nodes) == 0 for nodes in self._compositions.values())
+        return all(len(nodes) == 0 for nodes in self.compositions.values())
 
     def has_node_type(self, node_type: type) -> bool:
         """Return true if the composite node has at least one node of the given type, false otherwise.
@@ -339,7 +339,7 @@ class CompositeNode(Node):
         :param node_type: The type of the node
         :return:
         """
-        for nodes in self._compositions.values():
+        for nodes in self.compositions.values():
             for node in nodes:
                 if isinstance(node, node_type):
                     return True
@@ -349,6 +349,18 @@ class CompositeNode(Node):
 
         return False
 
+    def remove_node_types(self, types: list[type]):
+        """Exclude all the task nodes from the playbook.
+
+        :return:
+        """
+        for target_composition, nodes in self.compositions.items():
+            for node in nodes[:]:
+                if isinstance(node, tuple(types)):
+                    self.remove_node(target_composition, node)
+                elif isinstance(node, CompositeNode):
+                    node.remove_node_types(types)
+
     def to_dict(self, **kwargs) -> dict:
         """Return a dictionary representation of this composite node. This representation is not meant to get the
         original object back.
@@ -357,7 +369,7 @@ class CompositeNode(Node):
         """
         node_dict = super().to_dict(**kwargs)
 
-        for composition, nodes in self._compositions.items():
+        for composition, nodes in self.compositions.items():
             nodes_dict_list = []
             for node in nodes:
                 nodes_dict_list.append(node.to_dict(**kwargs))
@@ -444,7 +456,7 @@ class PlaybookNode(CompositeNode):
             self.remove_node("plays", play)
 
     def exclude_plays_without_roles(self):
-        """Exclude the plays that do not have roles.
+        """Exclude the plays that do not have roles from the playbook.
 
         :return:
         """
@@ -475,6 +487,13 @@ class PlaybookNode(CompositeNode):
             )
 
         return playbook_dict
+
+    def exclude_tasks(self):
+        """Exclude all the task nodes from the playbook.
+
+        :return:
+        """
+        self.remove_node_types([TaskNode])
 
 
 class PlayNode(CompositeNode):

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -211,7 +211,7 @@ class CompositeNode(Node):
         )
         self.supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition: plays, tasks, roles...
-        self.compositions = defaultdict(list)  # type: dict[str, list]
+        self._compositions = defaultdict(list)  # type: dict[str, list]
 
     def _check_target_composition(self, target_composition: str) -> None:
         """Check if the target composition is supported.
@@ -233,7 +233,7 @@ class CompositeNode(Node):
         :return:
         """
         self._check_target_composition(target_composition)
-        self.compositions[target_composition].append(node)
+        self._compositions[target_composition].append(node)
 
     def remove_node(self, target_composition: str, node: Node) -> None:
         """Remove a node from the target composition.
@@ -243,7 +243,7 @@ class CompositeNode(Node):
         :return:
         """
         self._check_target_composition(target_composition)
-        self.compositions[target_composition].remove(node)
+        self._compositions[target_composition].remove(node)
 
     def calculate_indices(self):
         """
@@ -252,7 +252,7 @@ class CompositeNode(Node):
         """
         current_index = 1
         for comp_type in self.supported_compositions:
-            for node in self.compositions[comp_type]:
+            for node in self._compositions[comp_type]:
                 node.index = current_index
                 current_index += 1
 
@@ -266,7 +266,7 @@ class CompositeNode(Node):
         :return: A list of the nodes.
         """
         self._check_target_composition(target_composition)
-        return self.compositions[target_composition]
+        return self._compositions[target_composition]
 
     def get_all_tasks(self) -> list["TaskNode"]:
         """Return all the TaskNode inside this composite node.
@@ -292,7 +292,7 @@ class CompositeNode(Node):
         :param acc: The accumulator
         :return:
         """
-        for _, nodes in self.compositions.items():
+        for _, nodes in self._compositions.items():
             for node in nodes:
                 if isinstance(node, node_type):
                     acc.append(node)
@@ -314,7 +314,7 @@ class CompositeNode(Node):
 
         :return:
         """
-        for nodes in self.compositions.values():
+        for nodes in self._compositions.values():
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     node._get_all_links(links)
@@ -326,12 +326,12 @@ class CompositeNode(Node):
         A composite node is considered empty if all its compositions are empty.
         :return:
         """
-        for nodes in self.compositions.values():
+        for nodes in self._compositions.values():
             for node in nodes:
                 if isinstance(node, CompositeNode):
                     return node.is_empty()
 
-        return all(len(nodes) == 0 for nodes in self.compositions.values())
+        return all(len(nodes) == 0 for nodes in self._compositions.values())
 
     def has_node_type(self, node_type: type) -> bool:
         """Return true if the composite node has at least one node of the given type, false otherwise.
@@ -339,7 +339,7 @@ class CompositeNode(Node):
         :param node_type: The type of the node
         :return:
         """
-        for nodes in self.compositions.values():
+        for nodes in self._compositions.values():
             for node in nodes:
                 if isinstance(node, node_type):
                     return True
@@ -354,7 +354,7 @@ class CompositeNode(Node):
 
         :return:
         """
-        for target_composition, nodes in self.compositions.items():
+        for target_composition, nodes in self._compositions.items():
             for node in nodes[:]:
                 if isinstance(node, tuple(types)):
                     self.remove_node(target_composition, node)
@@ -377,7 +377,7 @@ class CompositeNode(Node):
         # TODO: check if this is really needed
         list(map(self._check_target_composition, exclude_compositions))
 
-        for composition, nodes in self.compositions.items():
+        for composition, nodes in self._compositions.items():
             if composition in exclude_compositions:
                 node_dict[composition] = []
             else:

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -167,12 +167,8 @@ class Node:
             "name": self.name,
             "when": self.when,
             "index": self.index,
+            "location": asdict(self.location) if self.location else None,
         }
-
-        if self.location is not None:
-            data["location"] = asdict(self.location)
-        else:
-            data["location"] = None
 
         return data
 

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -424,6 +424,7 @@ class PlaybookNode(CompositeNode):
                 column=1,
             )
 
+    @property
     def plays(
         self,
     ) -> list["PlayNode"]:
@@ -431,9 +432,8 @@ class PlaybookNode(CompositeNode):
 
         :return:
         """
-        plays = self.get_nodes("plays")
 
-        return plays
+        return self.get_nodes("plays")
 
     def roles_usage(self) -> dict["RoleNode", set["PlayNode"]]:
         """For each role in the playbook, get the uniq plays that reference the role.
@@ -460,7 +460,7 @@ class PlaybookNode(CompositeNode):
 
         :return:
         """
-        to_exclude = [play for play in self.plays() if play.is_empty()]
+        to_exclude = [play for play in self.plays if play.is_empty()]
 
         for play in to_exclude:
             self.remove_node("plays", play)
@@ -470,25 +470,10 @@ class PlaybookNode(CompositeNode):
 
         :return:
         """
-        to_exclude = [play for play in self.plays() if not play.has_node_type(RoleNode)]
+        to_exclude = [play for play in self.plays if not play.has_node_type(RoleNode)]
 
         for play in to_exclude:
             self.remove_node("plays", play)
-
-    def to_dict(
-        self,
-        exclude_compositions: list[str] | None = None,
-        **kwargs,
-    ) -> dict:
-        """Return a dictionary representation of this playbook.
-
-        :param exclude_compositions: List of compositions to exclude from the output.
-        :param kwargs:
-        :return:
-        """
-        playbook_dict = super().to_dict(**kwargs)
-
-        return playbook_dict
 
     def exclude_tasks_node(self):
         """Exclude all the task nodes from the playbook.
@@ -737,16 +722,16 @@ class RoleNode(LoopMixin, CompositeNode):
     def to_dict(
         self,
         exclude_compositions: list[str] | None = None,
-        include_role_tasks: bool = False,
         include_handlers: bool = False,
+        include_role_tasks: bool = False,
         **kwargs,
     ) -> dict:
         """Return a dictionary representation of this composite node. This representation is not meant to get the
         original object back.
 
         :param exclude_compositions: List of compositions to exclude from the output.
-        :param include_role_tasks: Whether to include the role tasks in the output or not.
         :param include_handlers: Whether to include the handlers in the output or not
+        :param include_role_tasks: Whether to include the role tasks in the output or not.
         :param kwargs:
         :return:
         """

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -209,9 +209,21 @@ class CompositeNode(Node):
             raw_object=raw_object,
             parent=parent,
         )
-        self._supported_compositions = supported_compositions or []
+        self.supported_compositions = supported_compositions or []
         # The dict will contain the different types of composition: plays, tasks, roles...
         self._compositions = defaultdict(list)  # type: dict[str, list]
+
+    def _check_target_composition(self, target_composition: str) -> None:
+        """Check if the target composition is supported.
+
+        :param target_composition:
+        :return:
+        """
+        if target_composition not in self.supported_compositions:
+            msg = f"The target composition '{target_composition}' is unknown. Supported ones are: {self.supported_compositions}"
+            raise ValueError(
+                msg,
+            )
 
     def add_node(self, target_composition: str, node: Node) -> None:
         """Add a node in the target composition.
@@ -220,11 +232,7 @@ class CompositeNode(Node):
         :param node: The node to add in the given composition
         :return:
         """
-        if target_composition not in self._supported_compositions:
-            msg = f"The target composition '{target_composition}' is unknown. Supported are: {self._supported_compositions}"
-            raise ValueError(
-                msg,
-            )
+        self._check_target_composition(target_composition)
         self._compositions[target_composition].append(node)
 
     def remove_node(self, target_composition: str, node: Node) -> None:
@@ -234,11 +242,7 @@ class CompositeNode(Node):
         :param node: The node to remove from the given composition
         :return:
         """
-        if target_composition not in self._supported_compositions:
-            msg = f"The target composition '{target_composition}' is unknown. Supported are: {self._supported_compositions}"
-            raise ValueError(
-                msg,
-            )
+        self._check_target_composition(target_composition)
         self._compositions[target_composition].remove(node)
 
     def calculate_indices(self):
@@ -247,7 +251,7 @@ class CompositeNode(Node):
         This is only called when needed.
         """
         current_index = 1
-        for comp_type in self._supported_compositions:
+        for comp_type in self.supported_compositions:
             for node in self._compositions[comp_type]:
                 node.index = current_index
                 current_index += 1
@@ -261,12 +265,7 @@ class CompositeNode(Node):
         :param target_composition:
         :return: A list of the nodes.
         """
-        if target_composition not in self._supported_compositions:
-            msg = f"The target composition '{target_composition}' is unknown. Supported ones are: {self._supported_compositions}"
-            raise Exception(
-                msg,
-            )
-
+        self._check_target_composition(target_composition)
         return self._compositions[target_composition]
 
     def get_all_tasks(self) -> list["TaskNode"]:
@@ -293,8 +292,7 @@ class CompositeNode(Node):
         :param acc: The accumulator
         :return:
         """
-        items = self._compositions.items()
-        for _, nodes in items:
+        for _, nodes in self._compositions.items():
             for node in nodes:
                 if isinstance(node, node_type):
                     acc.append(node)

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -570,39 +570,6 @@ class PlayNode(CompositeNode):
 
         return data
 
-    def filter(self, include_handlers: bool = False) -> "PlayNode":
-        """Return a new play node by applying the filters.
-
-        :param include_handlers: Whether to include the handlers in the output or not
-        :return:
-        """
-        new_play = PlayNode(
-            node_name=self.name,
-            node_id=self.id,
-            when=self.when,
-            raw_object=self.raw_object,
-            hosts=self.hosts,
-            parent=self.parent,
-        )
-
-        for pre_task in self.pre_tasks:
-            new_play.add_node("pre_tasks", pre_task)
-
-        for role in self.roles:
-            new_play.add_node("roles", role.filter(include_handlers=include_handlers))
-
-        for task in self.tasks:
-            new_play.add_node("tasks", task)
-
-        for post_task in self.post_tasks:
-            new_play.add_node("post_tasks", post_task)
-
-        if include_handlers:
-            for handler in self.handlers:
-                new_play.add_node("handlers", handler)
-
-        return new_play
-
 
 class BlockNode(CompositeNode):
     """A block node: https://docs.ansible.com/ansible/latest/user_guide/playbooks_blocks.html."""
@@ -767,30 +734,6 @@ class RoleNode(LoopMixin, CompositeNode):
         :return:
         """
         return self.get_nodes("handlers")
-
-    def filter(self, include_handlers: bool = False) -> "RoleNode":
-        """Return a new role node by applying the filters.
-
-        :param include_handlers: Whether to include the handlers in the output or not
-        :return:
-        """
-        new_role = RoleNode(
-            node_name=self.name,
-            node_id=self.id,
-            when=self.when,
-            raw_object=self.raw_object,
-            include_role=self.include_role,
-            parent=self.parent,
-        )
-
-        for task in self.tasks:
-            new_role.add_node("tasks", task)
-
-        if include_handlers:
-            for handler in self.handlers:
-                new_role.add_node("handlers", handler)
-
-        return new_role
 
     def should_be_included(self) -> bool:
         """Return true if the role should be included in the graph, false otherwise.

--- a/ansibleplaybookgrapher/grapher.py
+++ b/ansibleplaybookgrapher/grapher.py
@@ -33,7 +33,6 @@ class Grapher:
 
     def parse(
         self,
-        include_role_tasks: bool = False,
         tags: list[str] | None = None,
         skip_tags: list[str] | None = None,
         group_roles_by_name: bool = False,
@@ -42,7 +41,6 @@ class Grapher:
     ) -> tuple[list[PlaybookNode], dict[RoleNode, set[PlayNode]]]:
         """Parses all the provided playbooks
 
-        :param include_role_tasks: Should we include the role tasks
         :param tags: Only add plays and tasks tagged with these values
         :param skip_tags: Only add plays and tasks whose tags do not match these values
         :param group_roles_by_name: Group roles by name instead of considering them as separate nodes with different IDs
@@ -60,7 +58,6 @@ class Grapher:
                 playbook_path=self.playbooks_mapping[playbook_arg],
                 tags=tags,
                 skip_tags=skip_tags,
-                include_role_tasks=include_role_tasks,
                 group_roles_by_name=group_roles_by_name,
                 playbook_name=playbook_arg,
                 exclude_roles=exclude_roles,

--- a/ansibleplaybookgrapher/grapher.py
+++ b/ansibleplaybookgrapher/grapher.py
@@ -37,15 +37,13 @@ class Grapher:
         skip_tags: list[str] | None = None,
         group_roles_by_name: bool = False,
         exclude_roles: list[str] | None = None,
-        only_roles: bool = False,
     ) -> tuple[list[PlaybookNode], dict[RoleNode, set[PlayNode]]]:
         """Parses all the provided playbooks
 
-        :param tags: Only add plays and tasks tagged with these values
+        :param tags: Only add plays and tasks tagged with these values.
         :param skip_tags: Only add plays and tasks whose tags do not match these values
-        :param group_roles_by_name: Group roles by name instead of considering them as separate nodes with different IDs
-        :param exclude_roles: Only add tasks whose roles do not match these values
-        :param only_roles: Ignore all task nodes when rendering graph
+        :param group_roles_by_name: Group roles by name instead of considering them as separate nodes with different IDs.
+        :param exclude_roles: Only add tasks whose roles do not match these values.
         :return: Tuple of the list of playbook nodes and the dictionary of the role usages: the key is the role and the
         value is the set of plays that use the role.
         """
@@ -61,7 +59,6 @@ class Grapher:
                 group_roles_by_name=group_roles_by_name,
                 playbook_name=playbook_arg,
                 exclude_roles=exclude_roles,
-                only_roles=only_roles,
             )
             playbook_node = playbook_parser.parse()
             playbook_node.index = counter

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -249,6 +249,7 @@ class PlaybookParser(BaseParser):
                 if role.get_name() in self.exclude_roles:
                     continue
 
+                """
                 # The role object doesn't inherit the tags from the play. So we add it manually.
                 role.tags = role.tags + play.tags
 
@@ -266,6 +267,7 @@ class PlaybookParser(BaseParser):
                     )
                     # Go to the next role
                     continue
+                """
 
                 if self.group_roles_by_name:
                     # If we are grouping roles, we use the hash of role name as the node id

--- a/ansibleplaybookgrapher/parser.py
+++ b/ansibleplaybookgrapher/parser.py
@@ -57,7 +57,9 @@ class BaseParser(ABC):
         tags: list[str] | None = None,
         skip_tags: list[str] | None = None,
     ) -> None:
-        """:param tags: Only add plays and tasks tagged with these values
+        """
+
+        :param tags: Only add plays and tasks tagged with these values
         :param skip_tags: Only add plays and tasks whose tags do not match these values
         """
         loader, inventory, variable_manager = CLI._play_prereqs()

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -152,7 +152,7 @@ class PlaybookBuilder(ABC):
     @abstractmethod
     def build_playbook(
         self,
-        show_handlers: bool = False,
+        show_handlers: bool,
         **kwargs,
     ) -> str:
         """Build the whole playbook

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -61,6 +61,7 @@ class Renderer(ABC):
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
+        ony_roles: bool = False,
         **kwargs,
     ) -> str:
         """Render the playbooks to a file.
@@ -74,6 +75,7 @@ class Renderer(ABC):
         :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph
         :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show the handlers or not.
+        :param ony_roles: Only render the roles without the tasks.
         :param kwargs:
         :return:
         """
@@ -92,6 +94,7 @@ class PlaybookBuilder(ABC):
         roles_usage: dict[RoleNode, set[PlayNode]] | None = None,
         roles_built: set[Node] | None = None,
         include_role_tasks: bool = False,
+        ony_roles: bool = False,
     ) -> None:
         """The base class for all playbook builders.
 
@@ -107,6 +110,7 @@ class PlaybookBuilder(ABC):
         # A map containing the roles that have been built so far
         self.roles_built = roles_built or set()
         self.include_role_tasks = include_role_tasks
+        self.ony_roles = ony_roles
 
         self.open_protocol_handler = open_protocol_handler
         # Merge the two dicts
@@ -133,6 +137,9 @@ class PlaybookBuilder(ABC):
                     role_node=node, color=color, fontcolor=fontcolor, **kwargs
                 )
         elif isinstance(node, TaskNode):
+            if self.ony_roles:
+                return
+
             self.build_task(
                 task_node=node,
                 color=color,

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -85,7 +85,7 @@ class PlaybookBuilder(ABC):
     def __init__(
         self,
         playbook_node: PlaybookNode,
-        open_protocol_handler: str,
+        open_protocol_handler: str | None,
         open_protocol_custom_formats: dict[str, str] | None = None,
         roles_usage: dict[RoleNode, set[PlayNode]] | None = None,
         roles_built: set[Node] | None = None,
@@ -110,9 +110,11 @@ class PlaybookBuilder(ABC):
         self.only_roles = only_roles
 
         self.open_protocol_handler = open_protocol_handler
+        self.open_protocol_formats = None
         # Merge the two dicts
         formats = {**OPEN_PROTOCOL_HANDLERS, "custom": open_protocol_custom_formats}
-        self.open_protocol_formats = formats[self.open_protocol_handler]
+        if self.open_protocol_handler:
+            self.open_protocol_formats = formats[self.open_protocol_handler]
 
     def build_node(self, node: Node, color: str, fontcolor: str, **kwargs) -> None:
         """Build a generic node.

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -79,7 +79,7 @@ class Renderer(ABC):
 
 class PlaybookBuilder(ABC):
     """This is the base class to inherit from by the renderer to build a single Playbook in the target format.
-    It provides some methods that need to be implemented.
+    It provides some methods that MUST be implemented.
     """
 
     def __init__(

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -58,8 +58,6 @@ class Renderer(ABC):
         title: str,
         include_role_tasks: bool = False,
         view: bool = False,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         ony_roles: bool = False,
         **kwargs,
@@ -72,8 +70,6 @@ class Renderer(ABC):
         :param title: The title of the graph.
         :param include_role_tasks: Whether to include the tasks of the roles in the graph or not.
         :param view: Whether to open the rendered file in the default viewer
-        :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show the handlers or not.
         :param ony_roles: Only render the roles without the tasks.
         :param kwargs:
@@ -155,14 +151,11 @@ class PlaybookBuilder(ABC):
     @abstractmethod
     def build_playbook(
         self,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build the whole playbook
-        :param hide_empty_plays: Whether to hide empty plays or not
-        :param hide_plays_without_roles: Whether to hide plays without roles or not
+
         :param show_handlers: Whether to show the handlers or not.
         :param kwargs:
         :return: The rendered playbook as a string.

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -323,7 +323,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
 
     def build_playbook(
         self,
-        show_handlers: bool = False,
+        show_handlers: bool,
         **kwargs,
     ) -> str:
         """Convert the PlaybookNode to the graphviz dot format.

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -55,7 +55,7 @@ class GraphvizRenderer(Renderer):
         include_role_tasks: bool = False,
         view: bool = False,
         show_handlers: bool = False,
-        ony_roles: bool = False,
+        only_roles: bool = False,
         **kwargs,
     ) -> str:
         """Render the playbooks to a file.
@@ -67,7 +67,7 @@ class GraphvizRenderer(Renderer):
         :param include_role_tasks: Whether to include the tasks of the roles in the graph or not.
         :param view: Whether to open the rendered file in the default viewer
         :param show_handlers: Whether to show the handlers or not.
-        :param ony_roles: Only render the roles without the tasks.
+        :param only_roles: Only render the roles without the tasks.
         :param kwargs:
         :return: The path of the rendered file.
         """
@@ -91,7 +91,7 @@ class GraphvizRenderer(Renderer):
                 roles_built=roles_built,
                 digraph=digraph,
                 include_role_tasks=include_role_tasks,
-                ony_roles=ony_roles,
+                only_roles=only_roles,
             )
 
             # TODO: move these parameters to the constructor
@@ -134,7 +134,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         roles_usage: dict[RoleNode, set[PlayNode]],
         roles_built: set[RoleNode],
         include_role_tasks: bool,
-        ony_roles: bool,
+        only_roles: bool,
         digraph: Digraph,
     ) -> None:
         """
@@ -148,7 +148,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             roles_usage=roles_usage,
             roles_built=roles_built,
             include_role_tasks=include_role_tasks,
-            ony_roles=ony_roles,
+            only_roles=only_roles,
         )
         self.digraph = digraph
 

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -352,7 +352,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         )
 
         for play in self.playbook_node.plays(
-            exclude_empty=hide_empty_plays,
+            exclude_empty_plays=hide_empty_plays,
             exclude_without_roles=hide_plays_without_roles,
         ):
             with self.digraph.subgraph(name=play.name) as play_subgraph:

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -54,8 +54,6 @@ class GraphvizRenderer(Renderer):
         title: str,
         include_role_tasks: bool = False,
         view: bool = False,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         ony_roles: bool = False,
         **kwargs,
@@ -68,8 +66,6 @@ class GraphvizRenderer(Renderer):
         :param title: The title of the graph.
         :param include_role_tasks: Whether to include the tasks of the roles in the graph or not.
         :param view: Whether to open the rendered file in the default viewer
-        :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show the handlers or not.
         :param ony_roles: Only render the roles without the tasks.
         :param kwargs:
@@ -100,8 +96,6 @@ class GraphvizRenderer(Renderer):
 
             # TODO: move these parameters to the constructor
             builder.build_playbook(
-                hide_empty_plays=hide_empty_plays,
-                hide_plays_without_roles=hide_plays_without_roles,
                 show_handlers=show_handlers,
             )
             roles_built.update(builder.roles_built)
@@ -329,15 +323,11 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
 
     def build_playbook(
         self,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Convert the PlaybookNode to the graphviz dot format.
 
-        :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not
         :param show_handlers: Whether to show the handlers or not.
         :return: The text representation of the graphviz dot format for the playbook.
         """
@@ -351,10 +341,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             URL=self.get_node_url(self.playbook_node),
         )
 
-        for play in self.playbook_node.plays(
-            exclude_empty_plays=hide_empty_plays,
-            exclude_without_roles=hide_plays_without_roles,
-        ):
+        for play in self.playbook_node.plays():
             with self.digraph.subgraph(name=play.name) as play_subgraph:
                 self.build_play(
                     play, digraph=play_subgraph, show_handlers=show_handlers, **kwargs

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -94,7 +94,6 @@ class GraphvizRenderer(Renderer):
                 only_roles=only_roles,
             )
 
-            # TODO: move these parameters to the constructor
             builder.build_playbook(
                 show_handlers=show_handlers,
             )
@@ -341,7 +340,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             URL=self.get_node_url(self.playbook_node),
         )
 
-        for play in self.playbook_node.plays():
+        for play in self.playbook_node.plays:
             with self.digraph.subgraph(name=play.name) as play_subgraph:
                 self.build_play(
                     play, digraph=play_subgraph, show_handlers=show_handlers, **kwargs

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -57,6 +57,7 @@ class GraphvizRenderer(Renderer):
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
+        ony_roles: bool = False,
         **kwargs,
     ) -> str:
         """Render the playbooks to a file.
@@ -70,6 +71,7 @@ class GraphvizRenderer(Renderer):
         :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph
         :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show the handlers or not.
+        :param ony_roles: Only render the roles without the tasks.
         :param kwargs:
         :return: The path of the rendered file.
         """
@@ -93,6 +95,7 @@ class GraphvizRenderer(Renderer):
                 roles_built=roles_built,
                 digraph=digraph,
                 include_role_tasks=include_role_tasks,
+                ony_roles=ony_roles,
             )
 
             # TODO: move these parameters to the constructor
@@ -137,6 +140,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         roles_usage: dict[RoleNode, set[PlayNode]],
         roles_built: set[RoleNode],
         include_role_tasks: bool,
+        ony_roles: bool,
         digraph: Digraph,
     ) -> None:
         """
@@ -150,8 +154,8 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
             roles_usage=roles_usage,
             roles_built=roles_built,
             include_role_tasks=include_role_tasks,
+            ony_roles=ony_roles,
         )
-
         self.digraph = digraph
 
     def build_task(

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -45,13 +45,15 @@ class JSONRenderer(Renderer):
         include_role_tasks: bool = False,
         view: bool = False,
         show_handlers: bool = False,
-        ony_roles: bool = False,
+        only_roles: bool = False,
         **kwargs,
     ) -> str:
         playbooks = []
 
         for playbook_node in self.playbook_nodes:
-            json_builder = JSONPlaybookBuilder(playbook_node, open_protocol_handler)
+            json_builder = JSONPlaybookBuilder(
+                playbook_node, open_protocol_handler, only_roles=only_roles
+            )
             json_builder.build_playbook(
                 show_handlers=show_handlers,
             )
@@ -83,8 +85,10 @@ class JSONRenderer(Renderer):
 
 
 class JSONPlaybookBuilder(PlaybookBuilder):
-    def __init__(self, playbook_node: PlaybookNode, open_protocol_handler: str) -> None:
-        super().__init__(playbook_node, open_protocol_handler)
+    def __init__(
+        self, playbook_node: PlaybookNode, open_protocol_handler: str, only_roles: bool
+    ) -> None:
+        super().__init__(playbook_node, open_protocol_handler, only_roles=only_roles)
 
         self.json_output = {}
 
@@ -105,6 +109,7 @@ class JSONPlaybookBuilder(PlaybookBuilder):
 
         self.json_output = self.playbook_node.to_dict(
             include_handlers=show_handlers,
+            only_roles=self.only_roles,
         )
 
         return json.dumps(self.json_output)

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -46,6 +46,7 @@ class JSONRenderer(Renderer):
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
+        ony_roles: bool = False,
         **kwargs,
     ) -> str:
         playbooks = []

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -42,9 +42,8 @@ class JSONRenderer(Renderer):
         open_protocol_custom_formats: dict[str, str] | None,
         output_filename: str,
         title: str,
+        include_role_tasks: bool = False,
         view: bool = False,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         ony_roles: bool = False,
         **kwargs,
@@ -54,8 +53,6 @@ class JSONRenderer(Renderer):
         for playbook_node in self.playbook_nodes:
             json_builder = JSONPlaybookBuilder(playbook_node, open_protocol_handler)
             json_builder.build_playbook(
-                hide_empty_plays=hide_empty_plays,
-                hide_plays_without_roles=hide_plays_without_roles,
                 show_handlers=show_handlers,
             )
 
@@ -93,15 +90,11 @@ class JSONPlaybookBuilder(PlaybookBuilder):
 
     def build_playbook(
         self,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build a playbook.
 
-        :param hide_empty_plays:
-        :param hide_plays_without_roles:
         :param show_handlers: Whether to show handlers or not
         :param kwargs:
         :return:
@@ -111,8 +104,6 @@ class JSONPlaybookBuilder(PlaybookBuilder):
         )
 
         self.json_output = self.playbook_node.to_dict(
-            exclude_empty_plays=hide_empty_plays,
-            exclude_plays_without_roles=hide_plays_without_roles,
             include_handlers=show_handlers,
         )
 

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -38,8 +38,8 @@ class JSONRenderer(Renderer):
 
     def render(
         self,
-        open_protocol_handler: str | None,
-        open_protocol_custom_formats: dict[str, str] | None,
+        open_protocol_handler: str,
+        open_protocol_custom_formats: dict[str, str],
         output_filename: str,
         title: str,
         include_role_tasks: bool = False,
@@ -53,7 +53,8 @@ class JSONRenderer(Renderer):
         for playbook_node in self.playbook_nodes:
             json_builder = JSONPlaybookBuilder(
                 playbook_node,
-                open_protocol_handler="", # Not supported
+                open_protocol_handler=open_protocol_handler,
+                open_protocol_custom_formats=open_protocol_custom_formats,
                 only_roles=only_roles,
                 include_role_tasks=include_role_tasks,
             )

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -53,7 +53,7 @@ class JSONRenderer(Renderer):
         for playbook_node in self.playbook_nodes:
             json_builder = JSONPlaybookBuilder(
                 playbook_node,
-                open_protocol_handler,
+                open_protocol_handler="", # Not supported
                 only_roles=only_roles,
                 include_role_tasks=include_role_tasks,
             )

--- a/ansibleplaybookgrapher/renderer/json.py
+++ b/ansibleplaybookgrapher/renderer/json.py
@@ -52,7 +52,10 @@ class JSONRenderer(Renderer):
 
         for playbook_node in self.playbook_nodes:
             json_builder = JSONPlaybookBuilder(
-                playbook_node, open_protocol_handler, only_roles=only_roles
+                playbook_node,
+                open_protocol_handler,
+                only_roles=only_roles,
+                include_role_tasks=include_role_tasks,
             )
             json_builder.build_playbook(
                 show_handlers=show_handlers,
@@ -62,8 +65,8 @@ class JSONRenderer(Renderer):
 
         output = {
             "version": 1,
-            "playbooks": playbooks,
             "title": title,
+            "playbooks": playbooks,
         }
 
         final_output_path_file = Path(f"{output_filename}.json")
@@ -86,15 +89,15 @@ class JSONRenderer(Renderer):
 
 class JSONPlaybookBuilder(PlaybookBuilder):
     def __init__(
-        self, playbook_node: PlaybookNode, open_protocol_handler: str, only_roles: bool
+        self, playbook_node: PlaybookNode, open_protocol_handler: str, **kwargs
     ) -> None:
-        super().__init__(playbook_node, open_protocol_handler, only_roles=only_roles)
+        super().__init__(playbook_node, open_protocol_handler, **kwargs)
 
         self.json_output = {}
 
     def build_playbook(
         self,
-        show_handlers: bool = False,
+        show_handlers: bool,
         **kwargs,
     ) -> str:
         """Build a playbook.
@@ -108,8 +111,7 @@ class JSONPlaybookBuilder(PlaybookBuilder):
         )
 
         self.json_output = self.playbook_node.to_dict(
-            include_handlers=show_handlers,
-            only_roles=self.only_roles,
+            include_handlers=show_handlers, include_role_tasks=self.include_role_tasks
         )
 
         return json.dumps(self.json_output)

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -45,9 +45,10 @@ class MermaidFlowChartRenderer(Renderer):
         open_protocol_custom_formats: dict[str, str],
         output_filename: str,
         title: str,
+        include_role_tasks: bool = False,
         view: bool = False,
         show_handlers: bool = False,
-        ony_roles: bool = False,
+        only_roles: bool = False,
         directive: str = DEFAULT_DIRECTIVE,
         orientation: str = DEFAULT_ORIENTATION,
         **kwargs,
@@ -60,7 +61,7 @@ class MermaidFlowChartRenderer(Renderer):
         :param title: The title of the graph.
         :param view: Not supported for the moment.
         :param show_handlers: Whether to show handlers or not.
-        :param ony_roles: Only render the roles without the tasks.
+        :param only_roles: Only render the roles without the tasks.
         :param directive: Mermaid directive.
         :param orientation: Mermaid graph orientation.
         :param kwargs:
@@ -92,7 +93,8 @@ class MermaidFlowChartRenderer(Renderer):
                 roles_usage=self.roles_usage,
                 roles_built=roles_built,
                 link_order=link_order,
-                ony_roles=ony_roles,
+                include_role_tasks=include_role_tasks,
+                only_roles=only_roles,
             )
 
             mermaid_code += playbook_builder.build_playbook(
@@ -155,7 +157,8 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         open_protocol_custom_formats: dict[str, str],
         roles_usage: dict[RoleNode, set[PlayNode]],
         roles_built: set[RoleNode],
-        ony_roles: bool,
+        include_role_tasks: bool,
+        only_roles: bool,
         link_order: int = 0,
     ) -> None:
         super().__init__(
@@ -164,7 +167,8 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             open_protocol_custom_formats,
             roles_usage,
             roles_built,
-            ony_roles=ony_roles,
+            include_role_tasks=include_role_tasks,
+            only_roles=only_roles,
         )
 
         self.mermaid_code = ""
@@ -358,14 +362,15 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         )
 
         # Role tasks
-        self._indentation_level += 1
-        for role_task in role_node.tasks:
-            self.build_node(
-                node=role_task,
-                color=node_color,
-                fontcolor=fontcolor,
-            )
-        self._indentation_level -= 1
+        if self.include_role_tasks:
+            self._indentation_level += 1
+            for role_task in role_node.tasks:
+                self.build_node(
+                    node=role_task,
+                    color=node_color,
+                    fontcolor=fontcolor,
+                )
+            self._indentation_level -= 1
 
         self.add_comment(f"End of the role '{role_node.display_name()}'")
 

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -46,8 +46,6 @@ class MermaidFlowChartRenderer(Renderer):
         output_filename: str,
         title: str,
         view: bool = False,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         ony_roles: bool = False,
         directive: str = DEFAULT_DIRECTIVE,
@@ -61,8 +59,6 @@ class MermaidFlowChartRenderer(Renderer):
         :param output_filename: The output filename without any extension.
         :param title: The title of the graph.
         :param view: Not supported for the moment.
-        :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph.
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show handlers or not.
         :param ony_roles: Only render the roles without the tasks.
         :param directive: Mermaid directive.
@@ -100,8 +96,6 @@ class MermaidFlowChartRenderer(Renderer):
             )
 
             mermaid_code += playbook_builder.build_playbook(
-                hide_empty_plays=hide_empty_plays,
-                hide_plays_without_roles=hide_plays_without_roles,
                 show_handlers=show_handlers,
             )
             link_order = playbook_builder.link_order
@@ -181,16 +175,11 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
 
     def build_playbook(
         self,
-        hide_empty_plays: bool = False,
-        hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
         **kwargs,
     ) -> str:
         """Build a playbook.
 
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not
-        :param hide_empty_plays: Whether to hide empty plays or not
-        :param hide_plays_without_roles: Whether to hide plays without any roles or not
         :param show_handlers: Whether to show handlers or not
         :param kwargs:
         :return:
@@ -208,10 +197,8 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         )
 
         self._indentation_level += 1
-        for play_node in self.playbook_node.plays(
-            exclude_empty_plays=hide_empty_plays,
-            exclude_without_roles=hide_plays_without_roles,
-        ):
+
+        for play_node in self.playbook_node.plays():
             self.build_play(play_node, show_handlers=show_handlers, **kwargs)
         self._indentation_level -= 1
 

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -59,6 +59,7 @@ class MermaidFlowChartRenderer(Renderer):
         :param open_protocol_custom_formats: Not supported for the moment.
         :param output_filename: The output filename without any extension.
         :param title: The title of the graph.
+        :param include_role_tasks: Whether to include the tasks of the roles or not.
         :param view: Not supported for the moment.
         :param show_handlers: Whether to show handlers or not.
         :param only_roles: Only render the roles without the tasks.

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -209,7 +209,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
 
         self._indentation_level += 1
         for play_node in self.playbook_node.plays(
-            exclude_empty=hide_empty_plays,
+            exclude_empty_plays=hide_empty_plays,
             exclude_without_roles=hide_plays_without_roles,
         ):
             self.build_play(play_node, show_handlers=show_handlers, **kwargs)

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -203,7 +203,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
 
         self._indentation_level += 1
 
-        for play_node in self.playbook_node.plays():
+        for play_node in self.playbook_node.plays:
             self.build_play(play_node, show_handlers=show_handlers, **kwargs)
         self._indentation_level -= 1
 

--- a/ansibleplaybookgrapher/renderer/mermaid.py
+++ b/ansibleplaybookgrapher/renderer/mermaid.py
@@ -49,6 +49,7 @@ class MermaidFlowChartRenderer(Renderer):
         hide_empty_plays: bool = False,
         hide_plays_without_roles: bool = False,
         show_handlers: bool = False,
+        ony_roles: bool = False,
         directive: str = DEFAULT_DIRECTIVE,
         orientation: str = DEFAULT_ORIENTATION,
         **kwargs,
@@ -63,6 +64,7 @@ class MermaidFlowChartRenderer(Renderer):
         :param hide_empty_plays: Whether to hide empty plays or not when rendering the graph.
         :param hide_plays_without_roles: Whether to hide plays without any roles or not.
         :param show_handlers: Whether to show handlers or not.
+        :param ony_roles: Only render the roles without the tasks.
         :param directive: Mermaid directive.
         :param orientation: Mermaid graph orientation.
         :param kwargs:
@@ -94,6 +96,7 @@ class MermaidFlowChartRenderer(Renderer):
                 roles_usage=self.roles_usage,
                 roles_built=roles_built,
                 link_order=link_order,
+                ony_roles=ony_roles,
             )
 
             mermaid_code += playbook_builder.build_playbook(
@@ -158,6 +161,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
         open_protocol_custom_formats: dict[str, str],
         roles_usage: dict[RoleNode, set[PlayNode]],
         roles_built: set[RoleNode],
+        ony_roles: bool,
         link_order: int = 0,
     ) -> None:
         super().__init__(
@@ -166,6 +170,7 @@ class MermaidFlowChartPlaybookBuilder(PlaybookBuilder):
             open_protocol_custom_formats,
             roles_usage,
             roles_built,
+            ony_roles=ony_roles,
         )
 
         self.mermaid_code = ""

--- a/ansibleplaybookgrapher/utils.py
+++ b/ansibleplaybookgrapher/utils.py
@@ -94,7 +94,8 @@ def get_play_colors(play_id: str) -> tuple[str, str]:
 
 
 def has_role_parent(task_block: Task) -> bool:
-    """Check if one of the parent of the task or block is a role
+    """Check if one of the parents of the task or block is a role.
+
     :param task_block:
     :return:
     """

--- a/tests/fixtures/nested-include-role.yml
+++ b/tests/fixtures/nested-include-role.yml
@@ -1,0 +1,13 @@
+---
+- hosts: all
+  roles:
+    - role: fake_role
+      when: ansible_distribution == "Debian"
+    - role: display_some_facts
+  tasks:
+    - block:
+        - include_role:
+            name: fake_role
+  post_tasks:
+    - include_role:
+        name: nested_include_role

--- a/tests/fixtures/roles/role-with-tagged-tasks/tasks/main.yml
+++ b/tests/fixtures/roles/role-with-tagged-tasks/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Task with a tag
+  ansible.builtin.debug:
+    msg: Msg from a task with the tag 'this_is_a_tag'
+  tags:
+    - this_is_a_tag
+
+- name: Another Task with a tag
+  ansible.builtin.debug:
+    msg: Msg from a task with with the tag 'this_is_a_another_tag'
+  tags:
+    - this_is_a_another_tag
+
+- name: A task with no tags
+  ansible.builtin.debug:
+    msg: Msg from a task without a tag

--- a/tests/fixtures/tags-and-roles.yml
+++ b/tests/fixtures/tags-and-roles.yml
@@ -1,0 +1,7 @@
+# https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html#adding-tags-to-roles
+---
+- name: test
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: role-with-tagged-tasks

--- a/tests/fixtures/tags-and-roles.yml
+++ b/tests/fixtures/tags-and-roles.yml
@@ -5,3 +5,5 @@
   gather_facts: false
   roles:
     - role: role-with-tagged-tasks
+      tags:
+        - role_tag

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -137,7 +137,9 @@ def test_has_node_type() -> None:
 
 
 def test_to_dict() -> None:
-    """:return:"""
+    """
+    :return:
+    """
     playbook = PlaybookNode("my-fake-playbook.yml")
     playbook.add_node("plays", PlayNode("empty"))
 
@@ -170,6 +172,28 @@ def test_to_dict() -> None:
     assert dict_rep["plays"][0]["tasks"][0]["type"] == "BlockNode"
 
 
+def test_role_to_dict_with_exclusion():
+    """
+    Test the method to_dict of the RoleNode
+    :return:
+    """
+    role = RoleNode("my_role")
+    role.add_node("tasks", TaskNode("task 1"))
+    role.add_node("tasks", TaskNode("task 2"))
+
+    dict_rep = role.to_dict(include_role_tasks=True)
+
+    assert dict_rep["type"] == "RoleNode"
+    assert dict_rep["name"] == "my_role"
+    assert dict_rep["tasks"][0]["name"] == "task 1"
+    assert dict_rep["tasks"][1]["name"] == "task 2"
+
+    dict_rep = role.to_dict()
+    assert dict_rep["type"] == "RoleNode"
+    assert dict_rep["name"] == "my_role"
+    assert len(dict_rep["tasks"]) == 0
+
+
 def test_remove_node_types():
     """
     Test the method remove_node_types
@@ -186,12 +210,12 @@ def test_remove_node_types():
     assert len(play.roles) == 1, "The role should be there"
     assert len(playbook.get_all_tasks()) == 1, "The task should be there"
 
-    playbook.remove_node_types([RoleNode])
+    playbook.remove_all_nodes_types([RoleNode])
     assert len(playbook.plays()) == 1
     assert len(play.roles) == 0, "The role should have been removed"
     assert len(playbook.get_all_tasks()) == 0, "The task should have been removed"
 
-    playbook.remove_node_types(
+    playbook.remove_all_nodes_types(
         [
             PlayNode,
         ]
@@ -213,5 +237,5 @@ def test_remove_node_types():
     role2.add_node("tasks", BlockNode("My block"))
 
     assert len(playbook.get_all_tasks()) == 11
-    playbook.remove_node_types([TaskNode, BlockNode])
+    playbook.remove_all_nodes_types([TaskNode, BlockNode])
     assert len(playbook.get_all_tasks()) == 0, "All tasks should have been removed"

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -44,15 +44,15 @@ def test_exclude_empty_plays() -> None:
     """
     playbook = PlaybookNode("my-playbook.yml")
     playbook.add_node("plays", PlayNode("empty"))
-    assert len(playbook.plays()) == 1, "There should be only one play"
+    assert len(playbook.plays) == 1, "There should be only one play"
     playbook.exclude_empty_plays()
-    assert len(playbook.plays()) == 0, "There should be no play"
+    assert len(playbook.plays) == 0, "There should be no play"
 
     play = PlayNode("play")
     playbook.add_node("plays", play)
     play.add_node("tasks", TaskNode("task 1"))
     playbook.exclude_empty_plays()
-    assert len(playbook.plays()) == 1, "There should be only one play"
+    assert len(playbook.plays) == 1, "There should be only one play"
 
 
 def test_exclude_plays_without_roles() -> None:
@@ -67,9 +67,9 @@ def test_exclude_plays_without_roles() -> None:
     playbook.add_node("plays", play_1)
     playbook.add_node("plays", play_2)
 
-    assert len(playbook.plays()) == 2, "There should be 2 plays"
+    assert len(playbook.plays) == 2, "There should be 2 plays"
     playbook.exclude_plays_without_roles()
-    assert len(playbook.plays()) == 1, "There should be only one play"
+    assert len(playbook.plays) == 1, "There should be only one play"
 
 
 def test_get_all_tasks_nodes() -> None:
@@ -206,12 +206,12 @@ def test_remove_node_types():
     role = RoleNode("my_role")
     role.add_node("tasks", TaskNode("task 1"))
     play.add_node("roles", role)
-    assert len(playbook.plays()) == 1
+    assert len(playbook.plays) == 1
     assert len(play.roles) == 1, "The role should be there"
     assert len(playbook.get_all_tasks()) == 1, "The task should be there"
 
     playbook.remove_all_nodes_types([RoleNode])
-    assert len(playbook.plays()) == 1
+    assert len(playbook.plays) == 1
     assert len(play.roles) == 0, "The role should have been removed"
     assert len(playbook.get_all_tasks()) == 0, "The task should have been removed"
 
@@ -220,7 +220,7 @@ def test_remove_node_types():
             PlayNode,
         ]
     )
-    assert len(playbook.plays()) == 0, "The play should have been removed"
+    assert len(playbook.plays) == 0, "The play should have been removed"
 
     assert playbook.is_empty(), "The playbook should be empty"
 

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -74,8 +74,12 @@ def test_empty_play() -> None:
     play = PlayNode("play")
     assert play.is_empty(), "The play should empty"
 
-    play.add_node("roles", RoleNode("my_role_1"))
-    assert not play.is_empty(), "The play should not be empty"
+    role = RoleNode("my_role_1")
+    play.add_node("roles", role)
+    assert play.is_empty(), "The play should still be empty given the role is empty"
+
+    role.add_node("tasks", TaskNode("task 1"))
+    assert not play.is_empty(), "The play should not be empty here"
 
 
 def test_has_node_type() -> None:

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -128,3 +128,6 @@ def test_to_dict() -> None:
     assert dict_rep["plays"][0]["tasks"][0]["name"] == "block 1"
     assert dict_rep["plays"][0]["tasks"][0]["index"] == 1
     assert dict_rep["plays"][0]["tasks"][0]["type"] == "BlockNode"
+
+
+# TODO: add a test for the only roles option/filter. It's no longer set when parsing the playbook

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -168,6 +168,3 @@ def test_to_dict() -> None:
     assert dict_rep["plays"][0]["tasks"][0]["name"] == "block 1"
     assert dict_rep["plays"][0]["tasks"][0]["index"] == 1
     assert dict_rep["plays"][0]["tasks"][0]["type"] == "BlockNode"
-
-
-# TODO: add a test for the only roles option/filter. It's no longer set when parsing the playbook

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -119,7 +119,8 @@ def test_to_dict() -> None:
 
     playbook.calculate_indices()
 
-    dict_rep = playbook.to_dict(exclude_empty_plays=True)
+    playbook.exclude_empty_plays()
+    dict_rep = playbook.to_dict()
 
     assert dict_rep["type"] == "PlaybookNode"
     assert dict_rep["location"] is None, "A fake playbook does not have a location"

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -37,6 +37,41 @@ def test_links_structure() -> None:
         assert e in all_links[role], f"The role should be linked to the edge {e}"
 
 
+def test_exclude_empty_plays() -> None:
+    """Test the exclusion of empty plays
+
+    :return:
+    """
+    playbook = PlaybookNode("my-playbook.yml")
+    playbook.add_node("plays", PlayNode("empty"))
+    assert len(playbook.plays()) == 1, "There should be only one play"
+    playbook.exclude_empty_plays()
+    assert len(playbook.plays()) == 0, "There should be no play"
+
+    play = PlayNode("play")
+    playbook.add_node("plays", play)
+    play.add_node("tasks", TaskNode("task 1"))
+    playbook.exclude_empty_plays()
+    assert len(playbook.plays()) == 1, "There should be only one play"
+
+
+def test_exclude_plays_without_roles() -> None:
+    """Test the exclusion of plays without roles.
+
+    :return:
+    """
+    playbook = PlaybookNode("my-playbook.yml")
+    play_1 = PlayNode("play 1")
+    play_2 = PlayNode("play 2")
+    play_1.add_node("roles", RoleNode("role 1"))
+    playbook.add_node("plays", play_1)
+    playbook.add_node("plays", play_2)
+
+    assert len(playbook.plays()) == 2, "There should be 2 plays"
+    playbook.exclude_plays_without_roles()
+    assert len(playbook.plays()) == 1, "There should be only one play"
+
+
 def test_get_all_tasks_nodes() -> None:
     """Test the function get_all_tasks_nodes
     :return:

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -303,9 +303,7 @@ def test_include_role(
 def test_with_block(request: pytest.FixtureRequest) -> None:
     """Test with_block.yml, an example with roles."""
     svg_path, playbook_paths = run_grapher(
-        ["with_block.yml"],
-        output_filename=request.node.name,
-        additional_args=["--include-role-tasks"],
+        ["with_block.yml"], output_filename=request.node.name
     )
 
     _common_tests(
@@ -315,7 +313,7 @@ def test_with_block(request: pytest.FixtureRequest) -> None:
         tasks_number=7,
         post_tasks_number=2,
         roles_number=1,
-        pre_tasks_number=4,
+        pre_tasks_number=1,
         blocks_number=4,
     )
 

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -635,7 +635,7 @@ def test_hiding_empty_plays_with_tags_filter_all(
             "--hide-empty-plays",
             "--tags",
             "fake-tag-that-does-not-exist",
-            "--include-role-tasks"
+            "--include-role-tasks",
         ],
     )
 

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -635,6 +635,7 @@ def test_hiding_empty_plays_with_tags_filter_all(
             "--hide-empty-plays",
             "--tags",
             "fake-tag-that-does-not-exist",
+            "--include-role-tasks"
         ],
     )
 

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -801,7 +801,7 @@ def test_only_roles_with_nested_include_roles(
     include_role_tasks_option: str,
     expected_roles_number: int,
 ) -> None:
-    """Test graphing a playbook with handlers
+    """Test graphing a playbook with the --only-roles flag.
 
     :param request:
     :return:

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -579,7 +579,7 @@ def test_group_roles_by_name(
 def test_hiding_plays(request: pytest.FixtureRequest) -> None:
     """Test hiding_plays with the flag --hide-empty-plays.
 
-    This case is about hiding plays with 0 zero task (no filtering)
+    This case is about hiding plays with zero tasks (no filtering)
     :param request:
     :return:
     """
@@ -787,4 +787,36 @@ def test_handlers_in_role(
         post_tasks_number=1,
         roles_number=1,
         handlers_number=handlers_number,
+    )
+
+
+@pytest.mark.parametrize(
+    ("include_role_tasks_option", "expected_roles_number"),
+    [("--", 4), ("--include-role-tasks", 6)],
+    ids=["no_include_role_tasks_option", "include_role_tasks_option"],
+)
+def test_only_roles_with_nested_include_roles(
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_roles_number: int,
+) -> None:
+    """Test graphing a playbook with handlers
+
+    :param request:
+    :return:
+    """
+    svg_path, playbook_paths = run_grapher(
+        ["nested-include-role.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "--only-roles",
+            include_role_tasks_option,
+        ],
+    )
+
+    _common_tests(
+        svg_filename=svg_path,
+        playbook_paths=playbook_paths,
+        plays_number=1,
+        roles_number=expected_roles_number,
     )

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -818,5 +818,6 @@ def test_only_roles_with_nested_include_roles(
         svg_filename=svg_path,
         playbook_paths=playbook_paths,
         plays_number=1,
+        blocks_number=1,
         roles_number=expected_roles_number,
     )

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -350,3 +350,5 @@ def test_handler_in_a_role(
         handlers_number=handlers_number,
         roles_number=1,
     )
+
+# TODO: add a test for the --only-roles flag for the json renderer

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -201,7 +201,6 @@ def test_simple_playbook(request: pytest.FixtureRequest) -> None:
         additional_args=[
             "-i",
             str(INVENTORY_PATH),
-            "--include-role-tasks",
             "--title",
             "My custom title",
         ],
@@ -219,13 +218,12 @@ def test_with_block(request: pytest.FixtureRequest) -> None:
         additional_args=[
             "-i",
             str(INVENTORY_PATH),
-            "--include-role-tasks",
         ],
     )
     _common_tests(
         json_path,
         plays_number=1,
-        pre_tasks_number=4,
+        pre_tasks_number=1,
         roles_number=1,
         tasks_number=7,
         blocks_number=4,
@@ -234,17 +232,11 @@ def test_with_block(request: pytest.FixtureRequest) -> None:
 
 
 @pytest.mark.parametrize(
-    ("flag", "roles_number", "tasks_number", "post_tasks_number"),
-    [("--", 6, 9, 8), ("--group-roles-by-name", 6, 9, 8)],
+    "flag",
+    ["--", "--group-roles-by-name"],
     ids=["no_group", "group"],
 )
-def test_group_roles_by_name(
-    request: pytest.FixtureRequest,
-    flag: str,
-    roles_number: int,
-    tasks_number: int,
-    post_tasks_number: int,
-) -> None:
+def test_group_roles_by_name(request: pytest.FixtureRequest, flag: str) -> None:
     """Test when grouping roles by name. This doesn't really affect the JSON renderer: multiple nodes will have the same ID.
     This test ensures that regardless of the flag '--group-roles-by-name', we get the same nodes in the output.
     :param request:
@@ -259,9 +251,9 @@ def test_group_roles_by_name(
     _common_tests(
         json_path,
         plays_number=1,
-        roles_number=roles_number,
-        tasks_number=tasks_number,
-        post_tasks_number=post_tasks_number,
+        roles_number=6,
+        tasks_number=9,
+        post_tasks_number=8,
         blocks_number=1,
     )
 

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -362,8 +362,9 @@ def test_only_roles_with_nested_include_roles(
     include_role_tasks_option: str,
     expected_roles_number: int,
 ) -> None:
-    """Test graphing a playbook with handlers
+    """Test graphing a playbook with the --only-roles flag.
 
+    For the JSON renderer, the empty roles are not excluded by design. As a result, the number of roles is different
     :param request:
     :return:
     """

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -351,4 +351,34 @@ def test_handler_in_a_role(
         roles_number=1,
     )
 
-# TODO: add a test for the --only-roles flag for the json renderer
+
+@pytest.mark.parametrize(
+    ("include_role_tasks_option", "expected_roles_number"),
+    [("--", 4), ("--include-role-tasks", 6)],
+    ids=["no_include_role_tasks_option", "include_role_tasks_option"],
+)
+def test_only_roles_with_nested_include_roles(
+    request: pytest.FixtureRequest,
+    include_role_tasks_option: str,
+    expected_roles_number: int,
+) -> None:
+    """Test graphing a playbook with handlers
+
+    :param request:
+    :return:
+    """
+    json_path, playbook_paths = run_grapher(
+        ["nested-include-role.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "--only-roles",
+            include_role_tasks_option,
+        ],
+    )
+
+    _common_tests(
+        json_path,
+        plays_number=1,
+        blocks_number=1,
+        roles_number=expected_roles_number,
+    )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -243,12 +243,15 @@ def test_include_role_parsing_with_exclude_roles(
         exclude_roles=exclude_roles,
     )
     playbook_node = parser.parse()
+    all_roles = get_all_roles([playbook_node])
 
     # If the exclude roles option is set, then there should be no roles with the names identical to the option arguments
-    if exclude_roles is not None:
-        all_roles = get_all_roles([playbook_node])
+    if exclude_roles:
         role_names = list(map(lambda role_node: role_node.name, all_roles))
         assert all(exclude_role not in role_names for exclude_role in exclude_roles)
+    else:
+        # If the exclude roles option is not set, then all roles should be included
+        assert len(all_roles) == 6
 
 
 @pytest.mark.parametrize("grapher_cli", [["with_block.yml"]], indirect=True)
@@ -333,7 +336,6 @@ def test_block_parsing(grapher_cli: PlaybookGrapherCLI) -> None:
 @pytest.mark.parametrize("grapher_cli", [["blocks_with_role.yml"]], indirect=True)
 def test_block_with_roles_parsing(grapher_cli: PlaybookGrapherCLI) -> None:
     """Test the parsing of a playbook with blocks and roles.
-
 
     :param grapher_cli:
     :return:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -234,6 +234,30 @@ def test_include_role_parsing_with_different_include_role_tasks(
     assert len(play_node.post_tasks[0].tasks) == nested_include_role_tasks_count
 
 
+@pytest.mark.parametrize("grapher_cli", [["tags-and-roles.yml"]], indirect=True)
+def test_parsing_tasks_with_tags_in_roles(grapher_cli: PlaybookGrapherCLI) -> None:
+    """Test a case where tags are attached to tasks inside the role but not the role itself.
+
+    When filtering with '-t tag', these tasks should be included in the graph.
+    :return:
+    """
+    parser = PlaybookParser(
+        grapher_cli.options.playbooks[0],
+        include_role_tasks=True,
+        tags=[
+            "this_is_a_tag"
+        ],
+    )
+    playbook_node = parser.parse()
+
+    assert len(playbook_node.plays()) == 1
+
+    play_node = playbook_node.plays()[0]
+    assert len(play_node.roles) == 1, "Only one role should be in the play"
+    role = play_node.roles[0]
+    assert len(role.tasks) == 1, "Only the tagged task should be included in the graph"
+
+
 @pytest.mark.parametrize(
     "exclude_roles",
     [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -56,7 +56,7 @@ def test_example_parsing(grapher_cli: PlaybookGrapherCLI, display: Display) -> N
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    assert len(playbook_node.plays()) == 1
+    assert len(playbook_node.plays) == 1
     assert playbook_node.location.path == str(FIXTURES_DIR_PATH / "example.yml")
     assert playbook_node.location.line == 1
     assert playbook_node.location.column == 1
@@ -64,7 +64,7 @@ def test_example_parsing(grapher_cli: PlaybookGrapherCLI, display: Display) -> N
         playbook_node.index is None
     ), "The index of the playbook should be None (it has no parent)"
 
-    play_node = playbook_node.plays()[0]
+    play_node = playbook_node.plays[0]
     assert play_node.location.path == str(FIXTURES_DIR_PATH / "example.yml")
     assert play_node.location.line == 2
     assert play_node.index == 1
@@ -97,8 +97,8 @@ def test_with_roles_parsing(grapher_cli: PlaybookGrapherCLI) -> None:
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    assert len(playbook_node.plays()) == 1
-    play_node = playbook_node.plays()[0]
+    assert len(playbook_node.plays) == 1
+    play_node = playbook_node.plays[0]
     assert play_node.index == 1
 
     assert len(play_node.roles) == 2
@@ -137,8 +137,8 @@ def test_include_role_parsing(
         grapher_cli.options.playbooks[0],
     )
     playbook_node = parser.parse()
-    assert len(playbook_node.plays()) == 1
-    play_node = playbook_node.plays()[0]
+    assert len(playbook_node.plays) == 1
+    play_node = playbook_node.plays[0]
     tasks = play_node.tasks
     assert len(tasks) == 6
 
@@ -200,9 +200,9 @@ def test_nested_include_role_parsing(
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    assert len(playbook_node.plays()) == 1
+    assert len(playbook_node.plays) == 1
 
-    play_node = playbook_node.plays()[0]
+    play_node = playbook_node.plays[0]
 
     assert (
         len(play_node.roles) == 2
@@ -259,9 +259,9 @@ def test_block_parsing(grapher_cli: PlaybookGrapherCLI) -> None:
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    assert len(playbook_node.plays()) == 1
+    assert len(playbook_node.plays) == 1
 
-    play_node = playbook_node.plays()[0]
+    play_node = playbook_node.plays[0]
     pre_tasks = play_node.pre_tasks
     tasks = play_node.tasks
     post_tasks = play_node.post_tasks
@@ -340,7 +340,7 @@ def test_block_with_roles_parsing(grapher_cli: PlaybookGrapherCLI) -> None:
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    play = playbook_node.plays()[0]
+    play = playbook_node.plays[0]
 
     assert len(play.pre_tasks) == 1
     assert isinstance(play.pre_tasks[0], BlockNode)
@@ -452,7 +452,7 @@ def test_roles_dependencies(grapher_cli: PlaybookGrapherCLI) -> None:
         grapher_cli.options.playbooks[0],
     )
     playbook_node = parser.parse()
-    roles = playbook_node.plays()[0].roles
+    roles = playbook_node.plays[0].roles
     assert len(roles) == 1, "Only one explicit role is called inside the playbook"
     role_with_dependencies = roles[0]
     tasks = role_with_dependencies.tasks
@@ -483,7 +483,7 @@ def test_roles_with_argument_validation(grapher_cli: PlaybookGrapherCLI) -> None
         grapher_cli.options.playbooks[0],
     )
     playbook_node = parser.parse()
-    roles = playbook_node.plays()[0].roles
+    roles = playbook_node.plays[0].roles
     assert len(roles) == 1, "Only one explicit role is called inside the playbook"
     role_with_dependencies = roles[0]
     tasks = role_with_dependencies.tasks
@@ -521,9 +521,9 @@ def test_parsing_playbook_in_collection(
     assert playbook_node.location.path == playbook_path
     assert playbook_node.location.line == 1
     assert playbook_node.location.column == 1
-    assert len(playbook_node.plays()) == 1
+    assert len(playbook_node.plays) == 1
 
-    play = playbook_node.plays()[0]
+    play = playbook_node.plays[0]
     roles = play.roles
     assert len(roles) == 2, "Two roles should be in the play"
 
@@ -540,10 +540,10 @@ def test_parsing_of_handlers(grapher_cli: PlaybookGrapherCLI) -> None:
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    plays = playbook_node.plays()
+    plays = playbook_node.plays
 
     assert len(plays) == 2
-    play_1, play_2 = playbook_node.plays()[0], playbook_node.plays()[1]
+    play_1, play_2 = playbook_node.plays[0], playbook_node.plays[1]
 
     assert len(play_1.pre_tasks) == 1, "The first play should have 1 pre_tasks"
     assert len(play_1.tasks) == 2, "The first play should have 2 tasks"
@@ -583,7 +583,7 @@ def test_parsing_handler_in_role(grapher_cli: PlaybookGrapherCLI) -> None:
     """
     parser = PlaybookParser(grapher_cli.options.playbooks[0])
     playbook_node = parser.parse()
-    plays = playbook_node.plays()
+    plays = playbook_node.plays
 
     assert len(plays) == 1
     play = plays[0]
@@ -617,9 +617,9 @@ def test_parsing_tasks_with_tags_in_roles(grapher_cli: PlaybookGrapherCLI) -> No
     )
     playbook_node = parser.parse()
 
-    assert len(playbook_node.plays()) == 1
+    assert len(playbook_node.plays) == 1
 
-    play_node = playbook_node.plays()[0]
+    play_node = playbook_node.plays[0]
     assert len(play_node.roles) == 1, "Only one role should be in the play"
     role = play_node.roles[0]
     assert len(role.tasks) == 1, "Only the tagged task should be included in the graph"


### PR DESCRIPTION
Related to #226

- fix: The tags on the role itself should not be evaluated. Instead, what we care about is the tasks (they inherit the tags set on the roles). More info [here.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html#adding-tags-to-roles) 
- "Empty roles" are no longer displayed by default. An empty role is a role with no tasks (after applying the tags filters for example). This is the same behavior as the option `--hide-empty-plays` but with roles. **I will eventually drop `--hide-empty-plays` to make this the default behavior in the future.**
- docs: Add a comparison matrix for the different renderers
- (Internal) Moved some flags out of the parser to the renderer instead. The whole playbook and all the tasks and roles (except the excluded ones) are always parsed. The renderer(s) will decide later what do based on the flags