### PR TITLE
doc/tests: import_role doesn't have the same behavior as include_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## What's Changed
 
+* fix: Make sure the import_role tasks are always added to the graph. More info
+  in https://github.com/haidaraM/ansible-playbook-grapher/pull/231.
 * feat: Add the handlers to the graph with `--show-handlers` (**initial support for handlers**). They are by default
   added at the end of the play and roles only. This might change in the future to actually reflect the handlers' behavior.
 * **Changes the shape of the graphviz node to make it consistent with Mermaid. The tasks will be rectangle instead of

--- a/README.md
+++ b/README.md
@@ -436,9 +436,10 @@ options:
                         same names. Default: False
   --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter).
   --hide-plays-without-roles
-                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play
-                        level and include_role as tasks are considered (no import_role).
-  --include-role-tasks  Include the tasks of the roles in the graph. Default: False
+                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as
+                        tasks are considered (no import_role).
+  --include-role-tasks  Include the tasks of the roles in the graph. Default: False. This only applies to roles at the play level and include_role tasks. The
+                        tasks from an 'import_role' are always added to the graph.
   --only-roles          Only render the roles in the graph (ignoring the tasks)
   --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
                         The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to
@@ -484,87 +485,8 @@ options:
                         be added automatically.
   -s, --save-dot-file   Save the graphviz dot file used to generate the graph.
   -t, --tags TAGS       only run plays and tasks tagged with these values. This argument may be specified multiple times.
-  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin
-                        plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, connection debugging might
-                        require -vvvv. This argument may be specified multiple times.
-❯ ansible-playbook-grapher --help | pbcopy
-❯ ansible-playbook-grapher --help
-usage: ansible-playbook-grapher [-h] [-v] [--exclude-roles EXCLUDE_ROLES] [--only-roles] [-i INVENTORY] [--include-role-tasks] [-s]
-                                [--view] [-o OUTPUT_FILENAME] [--open-protocol-handler {default,vscode,custom}]
-                                [--open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS] [--group-roles-by-name]
-                                [--renderer {graphviz,mermaid-flowchart,json}]
-                                [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
-                                [--renderer-mermaid-orientation {TD,RL,BT,RL,LR}] [--version] [--hide-plays-without-roles]
-                                [--hide-empty-plays] [--title TITLE] [--show-handlers] [-t TAGS] [--skip-tags SKIP_TAGS]
-                                [--vault-id VAULT_IDS] [-J | --vault-password-file VAULT_PASSWORD_FILES] [-e EXTRA_VARS]
-                                playbooks [playbooks ...]
-
-Make graphs from your Ansible Playbooks.
-
-positional arguments:
-  playbooks             Playbook(s) to graph. You can specify multiple playbooks, separated by spaces and reference playbooks in
-                        collections.
-
-options:
-  --exclude-roles EXCLUDE_ROLES
-                        Specify file path or comma separated list of roles, which should be excluded. This argument may be specified
-                        multiple times.
-  --group-roles-by-name
-                        When rendering the graph (graphviz and mermaid), only a single role will be displayed for all roles having the
-                        same names. Default: False
-  --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter).
-  --hide-plays-without-roles
-                        Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play
-                        level and include_role as tasks are considered (no import_role).
-  --include-role-tasks  Include the tasks of the roles in the graph. Default: False
-  --only-roles          Only render the roles in the graph (ignoring the tasks)
-  --open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS
-                        The custom formats to use as URLs for the nodes in the graph. Required if --open-protocol-handler is set to
-                        custom. You should provide a JSON formatted string like: {"file": "", "folder": ""}. Example: If you want to
-                        open folders (roles) inside the browser and files (tasks) in vscode, set it to: '{"file":
-                        "vscode://file/{path}:{line}:{column}", "folder": "{path}"}'. path: the absolute path to the file containing
-                        the the plays/tasks/roles. line/column: the position of the plays/tasks/roles in the file. You can optionally
-                        add the attribute "remove_from_path" to remove some parts of the path if you want relative paths.
-  --open-protocol-handler {default,vscode,custom}
-                        The protocol to use to open the nodes when double-clicking on them in your SVG viewer (only for graphviz). Your
-                        SVG viewer must support double-click and Javascript. The supported values are 'default', 'vscode' and 'custom'.
-                        For 'default', the URL will be the path to the file or folders. When using a browser, it will open or download
-                        them. For 'vscode', the folders and files will be open with VSCode. For 'custom', you need to set a custom
-                        format with --open-protocol-custom-formats.
-  --renderer {graphviz,mermaid-flowchart,json}
-                        The renderer to use to generate the graph. Default: graphviz
-  --renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE
-                        The directive for the mermaid renderer. Can be used to customize the output: fonts, theme, curve etc. More info
-                        at https://mermaid.js.org/config/directives.html. Default: '%%{ init: { "flowchart": { "curve": "bumpX" } }
-                        }%%'
-  --renderer-mermaid-orientation {TD,RL,BT,RL,LR}
-                        The orientation of the flow chart. Default: 'LR'
-  --show-handlers       Show the handlers in the graph. See the limitations in the project README on GitHub.
-  --skip-tags SKIP_TAGS
-                        only run plays and tasks whose tags do not match these values. This argument may be specified multiple times.
-  --title TITLE         The title to display in the graph. Default: 'Ansible Playbook Grapher'. Set it to an empty string to remove the
-                        title.
-  --vault-id VAULT_IDS  the vault identity to use. This argument may be specified multiple times.
-  --vault-password-file, --vault-pass-file VAULT_PASSWORD_FILES
-                        vault password file
-  --version             show program's version number and exit
-  --view                Automatically open the resulting SVG file with your system's default viewer application for the file type
-  -J, --ask-vault-password, --ask-vault-pass
-                        ask for vault password
-  -e, --extra-vars EXTRA_VARS
-                        set additional variables as key=value or YAML/JSON, if filename prepend with @. This argument may be specified
-                        multiple times.
-  -h, --help            show this help message and exit
-  -i, --inventory INVENTORY
-                        Specify inventory host path or comma separated host list. This argument may be specified multiple times.
-  -o, --output-file-name OUTPUT_FILENAME
-                        Output filename without the '.svg' extension (for graphviz), '.mmd' for Mermaid or `.json`. The extension will
-                        be added automatically.
-  -s, --save-dot-file   Save the graphviz dot file used to generate the graph.
-  -t, --tags TAGS       only run plays and tasks tagged with these values. This argument may be specified multiple times.
-  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin
-                        plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, connection debugging might
-                        require -vvvv. This argument may be specified multiple times.
+  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin plugins currently evaluate up to
+                        -vvvvvv. A reasonable level to start is -vvv, connection debugging might require -vvvv. This argument may be specified multiple times.
 ```
 
 ## Configuration: ansible.cfg

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -31,7 +31,6 @@ from ansible.utils.collection_loader._collection_finder import (
 from ansible.utils.display import Display
 
 from ansibleplaybookgrapher import __prog__, __version__
-from ansibleplaybookgrapher.graph_model import TaskNode
 from ansibleplaybookgrapher.grapher import Grapher
 from ansibleplaybookgrapher.renderer import OPEN_PROTOCOL_HANDLERS
 from ansibleplaybookgrapher.renderer.graphviz import GraphvizRenderer
@@ -214,7 +213,7 @@ class PlaybookGrapherCLI(CLI):
             dest="include_role_tasks",
             action="store_true",
             default=False,
-            help="Include the tasks of the roles in the graph. Default: %(default)s",
+            help="Include the tasks of the roles in the graph. Default: %(default)s. This only applies to roles at the play level and include_role tasks. The tasks from an 'import_role' are always added to the graph.",
         )
 
         self.parser.add_argument(

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -335,7 +335,7 @@ def test_nested_include_tasks(request: pytest.FixtureRequest) -> None:
 
 @pytest.mark.parametrize(
     ("include_role_tasks_option", "expected_tasks_number"),
-    [("--", 1), ("--include-role-tasks", 7)],
+    [("--", 4), ("--include-role-tasks", 7)],
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_import_role(
@@ -379,7 +379,7 @@ def test_import_playbook(request: pytest.FixtureRequest) -> None:
 
 @pytest.mark.parametrize(
     ("include_role_tasks_option", "expected_tasks_number"),
-    [("--", 4), ("--include-role-tasks", 7)],
+    [("--", 7), ("--include-role-tasks", 7)],
     ids=["no_include_role_tasks_option", "include_role_tasks_option"],
 )
 def test_nested_import_playbook(


### PR DESCRIPTION
Ansible executor engine treats them very differently:

- All `import*` statements are pre-processed at the time playbooks are parsed.
- All `include*` statements are processed as they are encountered during the execution of the playbook.

From https://docs.ansible.com/ansible/2.9/user_guide/playbooks_reuse_includes.html

---

What does mean for you: The tasks imported by an `import_role` are now **always added** to the graph regardless of the usage of `--include-role-tasks`. This behavior was introduced by #228. Since the `import*` statements are pre-processed when the playbook is parsed, it's not trivial to know the tasks are from an `import_role`. I might eventually change this if people want the same output as the `include_role` (a dedicated note for the import role as well).

## Example

From this playbook:

```yaml
# tmp.yml
---
  - hosts: all
    tags:
      - play1
    roles:
      - role: fake_role
        tags:
          - role_tag

    tasks:
      - name: Hello world
        debug:
          msg: Hello world
      - name: Import role
        import_role:
          name: display_some_facts
```

**Before:**

```mermaid
---
title: "ansible-playbook-grapher tmp.yml --renderer mermaid-flowchart"
---
%%{ init: { "flowchart": { "curve": "bumpX" } } }%%
flowchart LR
	%% Start of the playbook 'tmp.yml'
	playbook_338db25c("tmp.yml")
		%% Start of the play 'Play: all (0)'
		play_4f34a3fe["Play: all (0)"]
		style play_4f34a3fe fill:#bd0faa,color:#ffffff
		playbook_338db25c --> |"1"| play_4f34a3fe
		linkStyle 0 stroke:#bd0faa,color:#bd0faa
			%% Start of the role 'display_some_facts'
			play_4f34a3fe --> |"1"| role_ef0c80d6
			linkStyle 1 stroke:#bd0faa,color:#bd0faa
			role_ef0c80d6(["[role] display_some_facts"])
			style role_ef0c80d6 fill:#bd0faa,color:#ffffff,stroke:#bd0faa
			%% End of the role 'display_some_facts'
		%% End of the play 'Play: all (0)'
	%% End of the playbook 'tmp.yml'
```

```mermaid
---
title: "ansible-playbook-grapher tmp.yml --renderer mermaid-flowchart --view --include-role-tasks"
---
%%{ init: { "flowchart": { "curve": "bumpX" } } }%%
flowchart LR
	%% Start of the playbook 'tmp.yml'
	playbook_78d5da07("tmp.yml")
		%% Start of the play 'Play: all (0)'
		play_7d50a25e["Play: all (0)"]
		style play_7d50a25e fill:#1789b5,color:#ffffff
		playbook_78d5da07 --> |"1"| play_7d50a25e
		linkStyle 0 stroke:#1789b5,color:#1789b5
			%% Start of the role 'display_some_facts'
			play_7d50a25e --> |"1"| role_922b8a5b
			linkStyle 1 stroke:#1789b5,color:#1789b5
			role_922b8a5b(["[role] display_some_facts"])
			style role_922b8a5b fill:#1789b5,color:#ffffff,stroke:#1789b5
				task_99e90bea[" display_some_facts : ansible_architecture"]
				style task_99e90bea stroke:#1789b5,fill:#ffffff
				role_922b8a5b --> |"1"| task_99e90bea
				linkStyle 2 stroke:#1789b5,color:#1789b5
				task_20bff001[" display_some_facts : ansible_date_time"]
				style task_20bff001 stroke:#1789b5,fill:#ffffff
				role_922b8a5b --> |"2"| task_20bff001
				linkStyle 3 stroke:#1789b5,color:#1789b5
				task_613c1ada[" display_some_facts : Specific included task for Debian"]
				style task_613c1ada stroke:#1789b5,fill:#ffffff
				role_922b8a5b --> |"3"| task_613c1ada
				linkStyle 4 stroke:#1789b5,color:#1789b5
			%% End of the role 'display_some_facts'
			task_20de4095["[task]  display_some_facts : ansible_architecture"]
			style task_20de4095 stroke:#1789b5,fill:#ffffff
			play_7d50a25e --> |"2"| task_20de4095
			linkStyle 5 stroke:#1789b5,color:#1789b5
			task_bfce1de4["[task]  display_some_facts : ansible_date_time"]
			style task_bfce1de4 stroke:#1789b5,fill:#ffffff
			play_7d50a25e --> |"3"| task_bfce1de4
			linkStyle 6 stroke:#1789b5,color:#1789b5
			task_02381dee["[task]  display_some_facts : Specific included task for Debian"]
			style task_02381dee stroke:#1789b5,fill:#ffffff
			play_7d50a25e --> |"4"| task_02381dee
			linkStyle 7 stroke:#1789b5,color:#1789b5
		%% End of the play 'Play: all (0)'
	%% End of the playbook 'tmp.yml'
```

**After:**

```mermaid
---
title: "ansible-playbook-grapher tmp.yml --renderer mermaid-flowchart"
---
%%{ init: { "flowchart": { "curve": "bumpX" } } }%%
flowchart LR
    %% Start of the playbook 'tmp.yml'
    playbook_c9ae5c72("tmp.yml")
        %% Start of the play 'play #1 (all): 0'
        play_60a19b59["play #1 (all): 0"]
        style play_60a19b59 stroke:#2332a9,fill:#2332a9,color:#ffffff
        playbook_c9ae5c72 --> |"1"| play_60a19b59
        linkStyle 0 stroke:#2332a9,color:#2332a9
            %% Start of the role '[role] display_some_facts'
            play_60a19b59 --> |"1"| role_1f6f5a46
            linkStyle 1 stroke:#2332a9,color:#2332a9
            role_1f6f5a46(["[role] display_some_facts"])
            style role_1f6f5a46 fill:#2332a9,color:#ffffff,stroke:#2332a9
            %% End of the role '[role] display_some_facts'
            task_3a6c65d1["[task] display_some_facts : ansible_architecture"]
            style task_3a6c65d1 stroke:#2332a9,fill:#ffffff
            play_60a19b59 --> |"2"| task_3a6c65d1
            linkStyle 2 stroke:#2332a9,color:#2332a9
            task_166c627a["[task] display_some_facts : ansible_date_time"]
            style task_166c627a stroke:#2332a9,fill:#ffffff
            play_60a19b59 --> |"3"| task_166c627a
            linkStyle 3 stroke:#2332a9,color:#2332a9
            task_49929d0c["[task] display_some_facts : Specific included task for Debian"]
            style task_49929d0c stroke:#2332a9,fill:#ffffff
            play_60a19b59 --> |"4"| task_49929d0c
            linkStyle 4 stroke:#2332a9,color:#2332a9
        %% End of the play 'play #1 (all): 0'
    %% End of the playbook 'tmp.yml'
```


```mermaid
---
title: "ansible-playbook-grapher tmp.yml --renderer mermaid-flowchart --view --include-role-tasks"
---
%%{ init: { "flowchart": { "curve": "bumpX" } } }%%
flowchart LR
	%% Start of the playbook 'tmp.yml'
	playbook_e3c77447("tmp.yml")
		%% Start of the play 'play #1 (all): 0'
		play_dcbd8814["play #1 (all): 0"]
		style play_dcbd8814 stroke:#9b3181,fill:#9b3181,color:#ffffff
		playbook_e3c77447 --> |"1"| play_dcbd8814
		linkStyle 0 stroke:#9b3181,color:#9b3181
			%% Start of the role '[role] display_some_facts'
			play_dcbd8814 --> |"1"| role_91c83316
			linkStyle 1 stroke:#9b3181,color:#9b3181
			role_91c83316(["[role] display_some_facts"])
			style role_91c83316 fill:#9b3181,color:#ffffff,stroke:#9b3181
				task_d39cd275["[task] display_some_facts : ansible_architecture"]
				style task_d39cd275 stroke:#9b3181,fill:#ffffff
				role_91c83316 --> |"1"| task_d39cd275
				linkStyle 2 stroke:#9b3181,color:#9b3181
				task_0249518a["[task] display_some_facts : ansible_date_time"]
				style task_0249518a stroke:#9b3181,fill:#ffffff
				role_91c83316 --> |"2"| task_0249518a
				linkStyle 3 stroke:#9b3181,color:#9b3181
				task_7607b70a["[task] display_some_facts : Specific included task for Debian"]
				style task_7607b70a stroke:#9b3181,fill:#ffffff
				role_91c83316 --> |"3"| task_7607b70a
				linkStyle 4 stroke:#9b3181,color:#9b3181
			%% End of the role '[role] display_some_facts'
			task_fd594a53["[task] display_some_facts : ansible_architecture"]
			style task_fd594a53 stroke:#9b3181,fill:#ffffff
			play_dcbd8814 --> |"2"| task_fd594a53
			linkStyle 5 stroke:#9b3181,color:#9b3181
			task_ead21629["[task] display_some_facts : ansible_date_time"]
			style task_ead21629 stroke:#9b3181,fill:#ffffff
			play_dcbd8814 --> |"3"| task_ead21629
			linkStyle 6 stroke:#9b3181,color:#9b3181
			task_30dda673["[task] display_some_facts : Specific included task for Debian"]
			style task_30dda673 stroke:#9b3181,fill:#ffffff
			play_dcbd8814 --> |"4"| task_30dda673
			linkStyle 7 stroke:#9b3181,color:#9b3181
		%% End of the play 'play #1 (all): 0'
	%% End of the playbook 'tmp.yml'


```