### PR TITLE
fix: Remove empty blocks, fix index + rename some methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   at https://github.com/haidaraM/ansible-playbook-grapher/pull/231.**
 * **Changes the shape of the graphviz node to make it consistent with Mermaid. The tasks will be rectangle instead of
   `octagon`: https://graphviz.org/doc/info/shapes.html**
-* **fix: Remove the play name from the edge going from playbook to the plays. This was not consistent with the other edges.**
+* **fix: Remove the play name from the edge going from the playbook to the plays. This was not consistent with the other edges.**
 * **fix: The tags on the role itself should not be evaluated. Instead, what we care about is the tasks (they inherit the
   tags set on the roles).** More
   info [here.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html#adding-tags-to-roles)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * **fix: The tags on the role itself should not be evaluated. Instead, what we care about is the tasks (they inherit the
   tags set on the roles).** More
   info [here.](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tags.html#adding-tags-to-roles)
-* **"Empty roles" are no longer displayed by default**. An empty role is a role with no tasks (after applying the tags
+* **The empty roles and blocks are no longer displayed by default**. An empty role is a role with no tasks (after applying the tags
   filters, for example). This is the same behavior as the option `--hide-empty-plays` but with roles. **I will eventually
   drop `--hide-empty-plays` to make this the default behavior in the future.**
 * feat: Add the initial support for handlers to the graph with `--show-handlers`. They are by default

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Comparison of the renderers:
 | Highlight on hover                                       |         ✅         |             ❌              |                          ❌: NA                           |
 | Change graph orientation                                 |         ❌         |             ✅              |                          ❌: NA                           |
 | Group roles by name                                      |         ✅         |             ✅              | ✅: the roles with the same names will have the same IDs. |
-| Hide empty roles and blocks                              |         ✅         |             ✅              |        ❌: The empty roles are kept in the output         |
+| Hide empty roles and blocks                              |         ✅         |             ✅              |           ❌: They are kept in the JSON output            |
 | View the output file in your the OS default viewer       |         ✅         | ✅ on https://mermaid.live/ |                            ✅                             |
 | Tests of the output                                      |     Automatic     |   Manual (need a parser)   |                        Automatic                         |
 
@@ -435,7 +435,8 @@ options:
   --group-roles-by-name
                         When rendering the graph (graphviz and mermaid), only a single role will be displayed for all roles having the
                         same names. Default: False
-  --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter).
+  --hide-empty-plays    Hide the plays that end up with no tasks in the graph (after applying the tags filter). Will be removed in the next major version
+                        (v3.0.0) to make it the default behavior. Default: False
   --hide-plays-without-roles
                         Hide the plays that end up with no roles in the graph (after applying the tags filter). Only roles at the play level and include_role as
                         tasks are considered (no import_role).

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Comparison of the renderers:
 | Highlight on hover                                       |         ✅         |             ❌              |                          ❌: NA                           |
 | Change graph orientation                                 |         ❌         |             ✅              |                          ❌: NA                           |
 | Group roles by name                                      |         ✅         |             ✅              | ✅: the roles with the same names will have the same IDs. |
-| Hide empty roles                                         |         ✅         |             ✅              |        ❌: The empty roles are kept in the output         |
+| Hide empty roles and blocks                              |         ✅         |             ✅              |        ❌: The empty roles are kept in the output         |
 | View the output file in your the OS default viewer       |         ✅         | ✅ on https://mermaid.live/ |                            ✅                             |
 | Tests of the output                                      |     Automatic     |   Manual (need a parser)   |                        Automatic                         |
 

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -408,6 +408,11 @@ class PlaybookGrapherCLI(CLI):
 
             options.exclude_roles = sorted(exclude_roles)
 
+        if self.options.hide_empty_plays:
+            display.warning(
+                "The option --hide-empty-plays will be removed in the next major version (v3.0.0) to make it the default behavior.",
+            )
+
         if self.options.show_handlers:
             display.warning(
                 "The handlers are only partially supported for the moment. They are added at the end of the play and roles, "

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -83,13 +83,14 @@ class PlaybookGrapherCLI(CLI):
 
         for p in playbook_nodes:
             if self.options.hide_empty_plays:
-                p.exclude_empty_plays()
+                # TODO: This will be the default behavior in the next major version (v3.0.0)
+                p.remove_empty_plays()
 
             if self.options.hide_plays_without_roles:
-                p.exclude_plays_without_roles()
+                p.remove_plays_without_roles()
 
             if self.options.only_roles:
-                p.exclude_tasks_node()
+                p.remove_tasks_node()
 
             p.calculate_indices()
 

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -318,7 +318,7 @@ class PlaybookGrapherCLI(CLI):
             "--hide-empty-plays",
             action="store_true",
             default=False,
-            help="Hide the plays that end up with no tasks in the graph (after applying the tags filter).",
+            help="Hide the plays that end up with no tasks in the graph (after applying the tags filter). Will be removed in the next major version (v3.0.0) to make it the default behavior. Default: %(default)s",
         )
 
         self.parser.add_argument(

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -92,7 +92,7 @@ class PlaybookGrapherCLI(CLI):
             if self.options.only_roles:
                 p.remove_tasks_node()
 
-            p.calculate_indices()
+            p.calculate_indices(only_roles=self.options.only_roles)
 
         match self.options.renderer:
             case "graphviz":

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -128,11 +128,11 @@ class Node:
                 # Here we likely have a task with a validate argument spec task inserted by Ansible
                 pass
 
-    def get_first_parent_matching_type(self, node_type: type) -> type:
+    def get_first_parent_matching_type(self, node_type: type) -> type | None:
         """Get the first parent of this node matching the given type.
 
         :param node_type: The type of the parent node to get.
-        :return:
+        :return: The first parent matching the given type or None if no parent matches the type.
         """
         current_parent = self.parent
 
@@ -141,8 +141,7 @@ class Node:
                 return current_parent
             current_parent = current_parent.parent
 
-        msg = f"No parent of type {node_type} found for {self}"
-        raise ValueError(msg)
+        return None
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(name='{self.name}', id='{self.id}', index={self.index})"
@@ -665,6 +664,18 @@ class TaskNode(LoopMixin, Node):
             raw_object=raw_object,
             parent=parent,
         )
+
+    def display_name(self) -> str:
+        """Return the display name of the node.
+
+        When a task is from a role, we just display the name of the task. In this case, its name already contains the
+        role name.
+        :return:
+        """
+        if self.get_first_parent_matching_type(RoleNode):
+            return self.name
+
+        return super().display_name()
 
     def is_handler(self) -> bool:
         """Return true if this task is a handler, false otherwise.

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -251,14 +251,14 @@ class CompositeNode(Node):
         Calculate the indices of all nodes based on their composition type and whether they are supposed to be included
         or not.
 
-        :param only_roles: Whether to calculate the indices only for the roles or not.
+        :param only_roles: When in only roles, we need to skip the tasks.
         """
         current_index = 1
         for comp_type in self.supported_compositions:
             for node in self._compositions[comp_type]:
                 if (
                     isinstance(node, CompositeNode) and node.is_empty()
-                ) and not only_roles:  # Skip empty nodes
+                ) and not only_roles:  # Skip empty nodes when we don't need only roles
                     node.index = None
                     continue
 
@@ -338,15 +338,18 @@ class CompositeNode(Node):
     def is_empty(self) -> bool:
         """Return true if the composite node is empty, false otherwise.
 
-        A composite node is considered empty if all its compositions are empty.
+        A composite node with at least one task is not empty.
         :return:
         """
         for nodes in self._compositions.values():
             for node in nodes:
                 if isinstance(node, CompositeNode):
-                    return node.is_empty()
-
-        return all(len(nodes) == 0 for nodes in self._compositions.values())
+                    if not node.is_empty():
+                        return False
+                else:
+                    # We have a task node here => the composite node is not empty
+                    return False
+        return True
 
     def has_node_type(self, node_type: type) -> bool:
         """Return true if the composite node has at least one node of the given type, false otherwise.

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -392,18 +392,13 @@ class CompositeNode(Node):
         """
         node_dict = super().to_dict(**kwargs)
         exclude_compositions = exclude_compositions or []
-        # checking the exclude_compositions
-        # TODO: check if this is really needed
-        list(map(self._check_target_composition, exclude_compositions))
 
-        for composition, nodes in self._compositions.items():
+        for composition in self.supported_compositions:
             if composition in exclude_compositions:
                 node_dict[composition] = []
             else:
-                nodes_dict_list = []
-                for node in nodes:
-                    nodes_dict_list.append(node.to_dict(**kwargs))
-                node_dict[composition] = nodes_dict_list
+                nodes = self._compositions.get(composition, [])
+                node_dict[composition] = [node.to_dict(**kwargs) for node in nodes]
 
         return node_dict
 

--- a/ansibleplaybookgrapher/graph_model.py
+++ b/ansibleplaybookgrapher/graph_model.py
@@ -246,19 +246,33 @@ class CompositeNode(Node):
         self._check_target_composition(target_composition)
         self._compositions[target_composition].remove(node)
 
-    def calculate_indices(self):
+    def calculate_indices(self, only_roles: bool = False) -> None:
         """
         Calculate the indices of all nodes based on their composition type and whether they are supposed to be included
         or not.
+
+        :param only_roles: Whether to calculate the indices only for the roles or not.
         """
         current_index = 1
         for comp_type in self.supported_compositions:
             for node in self._compositions[comp_type]:
+                if (
+                    isinstance(node, CompositeNode) and node.is_empty()
+                ) and not only_roles:  # Skip empty nodes
+                    node.index = None
+                    continue
+
+                if (
+                    isinstance(node, TaskNode) and only_roles
+                ):  # Skip tasks when no needed
+                    node.index = None
+                    continue
+
                 node.index = current_index
                 current_index += 1
 
                 if isinstance(node, CompositeNode):
-                    node.calculate_indices()
+                    node.calculate_indices(only_roles=only_roles)
 
     def get_nodes(self, target_composition: str) -> list:
         """Get a node from the compositions.

--- a/ansibleplaybookgrapher/renderer/__init__.py
+++ b/ansibleplaybookgrapher/renderer/__init__.py
@@ -118,20 +118,25 @@ class PlaybookBuilder(ABC):
 
     def build_node(self, node: Node, color: str, fontcolor: str, **kwargs) -> None:
         """Build a generic node.
+
         :param node: The RoleNode to render
         :param color: The color to apply
         :param fontcolor: The font color to apply
         :return:
         """
         if isinstance(node, BlockNode):
-            self.build_block(
-                block_node=node,
-                color=color,
-                fontcolor=fontcolor,
-                **kwargs,
-            )
+            # Only build the block if it is not empty or if it has a role node when we only want roles
+            if not node.is_empty() or (
+                node.has_node_type(RoleNode) and self.only_roles
+            ):
+                self.build_block(
+                    block_node=node,
+                    color=color,
+                    fontcolor=fontcolor,
+                    **kwargs,
+                )
         elif isinstance(node, RoleNode):
-            if node.should_be_included() or self.only_roles:
+            if not node.is_empty() or self.only_roles:
                 self.build_role(
                     role_node=node, color=color, fontcolor=fontcolor, **kwargs
                 )
@@ -197,7 +202,7 @@ class PlaybookBuilder(ABC):
 
         # roles
         for role in play_node.roles:
-            if not role.should_be_included() and not self.only_roles:
+            if role.is_empty() and not self.only_roles:
                 continue
 
             self.build_role(

--- a/tests/fixtures/json-schemas/v1.json
+++ b/tests/fixtures/json-schemas/v1.json
@@ -33,7 +33,7 @@
             "type": "string"
           },
           "index": {
-            "type": "integer"
+            "type": ["integer", "null"]
           },
           "location": {
             "$ref": "#/$defs/location"
@@ -151,7 +151,7 @@
   ],
   "$defs": {
     "task": {
-      "description": "An Ansible task or role",
+      "description": "An Ansible task, block or role.",
       "type": "object",
       "properties": {
         "type": {
@@ -172,7 +172,7 @@
         },
         "index": {
           "description": "The index of the task",
-          "type": "integer"
+          "type": ["integer", "null"]
         },
         "location": {
           "$ref": "#/$defs/location"

--- a/tests/fixtures/with_block.yml
+++ b/tests/fixtures/with_block.yml
@@ -9,6 +9,8 @@
         - name: debug
           debug:
             msg: "pre task debug"
+          tags:
+            - pre_task_tag
   tasks:
     - name: Install tree
       yum:

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -37,26 +37,41 @@ def test_links_structure() -> None:
         assert e in all_links[role], f"The role should be linked to the edge {e}"
 
 
-def test_exclude_empty_plays() -> None:
-    """Test the exclusion of empty plays
+def test_empty_play_method() -> None:
+    """Testing the emptiness of a play
+    :return:
+    """
+    play = PlayNode("play")
+    assert play.is_empty(), "The play should empty"
+
+    role = RoleNode("my_role_1")
+    play.add_node("roles", role)
+    assert play.is_empty(), "The play should still be empty given the role is empty"
+
+    role.add_node("tasks", TaskNode("task 1"))
+    assert not play.is_empty(), "The play should not be empty here"
+
+
+def test_remove_empty_plays() -> None:
+    """Test removing empty plays from a playbook
 
     :return:
     """
     playbook = PlaybookNode("my-playbook.yml")
     playbook.add_node("plays", PlayNode("empty"))
     assert len(playbook.plays) == 1, "There should be only one play"
-    playbook.exclude_empty_plays()
+    playbook.remove_empty_plays()
     assert len(playbook.plays) == 0, "There should be no play"
 
     play = PlayNode("play")
     playbook.add_node("plays", play)
     play.add_node("tasks", TaskNode("task 1"))
-    playbook.exclude_empty_plays()
+    playbook.remove_empty_plays()
     assert len(playbook.plays) == 1, "There should be only one play"
 
 
-def test_exclude_plays_without_roles() -> None:
-    """Test the exclusion of plays without roles.
+def test_remove_plays_without_roles() -> None:
+    """Test removing plays without roles from a playbook
 
     :return:
     """
@@ -68,7 +83,7 @@ def test_exclude_plays_without_roles() -> None:
     playbook.add_node("plays", play_2)
 
     assert len(playbook.plays) == 2, "There should be 2 plays"
-    playbook.exclude_plays_without_roles()
+    playbook.remove_plays_without_roles()
     assert len(playbook.plays) == 1, "There should be only one play"
 
 
@@ -100,21 +115,6 @@ def test_get_all_tasks_nodes() -> None:
     all_tasks = play.get_all_tasks()
     assert len(all_tasks) == 4, "There should be 4 tasks in all"
     assert [task_1, task_2, task_3, task_4] == all_tasks
-
-
-def test_empty_play() -> None:
-    """Testing the emptiness of a play
-    :return:
-    """
-    play = PlayNode("play")
-    assert play.is_empty(), "The play should empty"
-
-    role = RoleNode("my_role_1")
-    play.add_node("roles", role)
-    assert play.is_empty(), "The play should still be empty given the role is empty"
-
-    role.add_node("tasks", TaskNode("task 1"))
-    assert not play.is_empty(), "The play should not be empty here"
 
 
 def test_has_node_type() -> None:
@@ -156,7 +156,7 @@ def test_to_dict() -> None:
 
     playbook.calculate_indices()
 
-    playbook.exclude_empty_plays()
+    playbook.remove_empty_plays()
     dict_rep = playbook.to_dict()
 
     assert dict_rep["type"] == "PlaybookNode"

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -48,6 +48,12 @@ def test_empty_play_method() -> None:
     play.add_node("roles", role)
     assert play.is_empty(), "The play should still be empty given the role is empty"
 
+    task = TaskNode("Block 1")
+    play.add_node("tasks", task)
+    assert not play.is_empty(), "The play should not be empty here"
+    play.remove_node("tasks", task)
+    assert play.is_empty(), "The play should be empty again"
+
     role.add_node("tasks", TaskNode("task 1"))
     assert not play.is_empty(), "The play should not be empty here"
 
@@ -266,11 +272,15 @@ def test_calculate_indices():
     playbook.calculate_indices(only_roles=False)
     assert play.index == 1
     assert role.index == 1
+    role.tasks[0].index = 1
+    role.tasks[0].index = 2
     assert nested_include_1.index == 3
     assert nested_include_2.index == 4
 
     playbook.calculate_indices(only_roles=True)
     assert play.index == 1
     assert role.index == 1
+    role.tasks[0].index = None
+    role.tasks[0].index = None
     assert nested_include_1.index == 1
     assert nested_include_2.index == 2

--- a/tests/test_json_renderer.py
+++ b/tests/test_json_renderer.py
@@ -231,6 +231,41 @@ def test_with_block(request: pytest.FixtureRequest) -> None:
     )
 
 
+def test_with_block_with_skip_tags(
+    request: pytest.FixtureRequest,
+) -> None:
+    """
+    :return:
+
+    """
+    json_path, playbook_paths = run_grapher(
+        ["with_block.yml"],
+        output_filename=request.node.name,
+        additional_args=[
+            "-i",
+            str(INVENTORY_PATH),
+            "--skip-tags",
+            "pre_task_tag",
+        ],
+    )
+    result = _common_tests(
+        json_path,
+        plays_number=1,
+        pre_tasks_number=0,
+        roles_number=1,
+        tasks_number=7,
+        blocks_number=4,
+        post_tasks_number=2,
+    )
+
+    blocks = result["blocks"]
+    # The first block should have None as an index
+    assert blocks[0]["index"] is None, "The first block should have None as an index"
+    assert (
+        len(blocks[0]["tasks"]) == 0
+    ), "The first block should have no tasks (skipped)"
+
+
 @pytest.mark.parametrize(
     "flag",
     ["--", "--group-roles-by-name"],


### PR DESCRIPTION
 - Empty blocks are no longer added to the graph.
 - Tasks in role should not have the `[task]` as a prefix.
 - `Node.index` can be `None`. This mean they will not be added to the graph (for graphviz and mermaid).
 - Fix `CompositeNode.is_empty()`