### PR TITLE
feat(svg): Add collapsible nodes for roles, plays, and blocks in SVG output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Here are a few break changes to expect in the next major release:
 - Rename the flag `--include-role-tasks` to `--show-role-tasks` (or something else) to avoid confusion with an
   `include_role` task.
 
+# 2.10.0 (unreleased)
+
+## What's Changed
+
+* feat(svg): Add collapsible nodes for plays, roles and blocks in SVG output by @haidaraM in https://github.com/haidaraM/ansible-playbook-grapher/pull/247
+  * Added a new `--collapsible-nodes` flag to enable collapse/expand buttons on play, role, and block nodes
+  * Clicking the buttons recursively hides or shows descendant nodes and edges
+  * Helps manage complexity in large graphs with many nested components
+
 # 2.9.2 (2025-05-18)
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Inspired by [Ansible Inventory Grapher](https://github.com/willthames/ansible-in
 - Support for `import_*` and `include_*`.
 - Multiple flags to hide empty plays, group roles by name, etc...
 - Support for playbooks in collections.
+doc- Collapsible play, role and block nodes in SVG output to help manage graph complexity (with `--collapsible-nodes` flag).
 
 The following features are available when opening the SVGs in a browser (recommended) or a viewer that supports
 JavaScript:
@@ -412,7 +413,7 @@ The available options:
 
 ```
 usage: ansible-playbook-grapher [-h] [-v] [--exclude-roles EXCLUDE_ROLES] [--only-roles] [-i INVENTORY] [--include-role-tasks] [-s]
-                                [--view] [-o OUTPUT_FILENAME] [--open-protocol-handler {default,vscode,custom}]
+                                [--collapsible-nodes] [--view] [-o OUTPUT_FILENAME] [--open-protocol-handler {default,vscode,custom}]
                                 [--open-protocol-custom-formats OPEN_PROTOCOL_CUSTOM_FORMATS] [--group-roles-by-name]
                                 [--renderer {graphviz,mermaid-flowchart,json}]
                                 [--renderer-mermaid-directive RENDERER_MERMAID_DIRECTIVE]
@@ -428,6 +429,7 @@ positional arguments:
                         collections.
 
 options:
+  --collapsible-nodes   Add collapse/expand buttons to play, role, and block nodes in the SVG output. Default: False
   --exclude-roles EXCLUDE_ROLES
                         Specify file path or comma separated list of roles, which should be excluded. This argument may be specified
                         multiple times.
@@ -527,7 +529,7 @@ To set up a new local development environment:
 > The project contains some collections in [collections](tests/fixtures/collections). If you modify them, you need to do
 > a force install with `ansible-galaxy install -r requirements.yml --force`
 
-Run the tests and open the generated files in your system’s default viewer application:
+Run the tests and open the generated files in your system's default viewer application:
 
 ```shell script
 export TEST_VIEW_GENERATED_FILE=1

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -109,6 +109,7 @@ class PlaybookGrapherCLI(CLI):
                     view=self.options.view,
                     show_handlers=self.options.show_handlers,
                     save_dot_file=self.options.save_dot_file,
+                    collapsible_nodes=self.options.collapsible_nodes,
                 )
 
             case "mermaid-flowchart":
@@ -221,6 +222,14 @@ class PlaybookGrapherCLI(CLI):
             action="store_true",
             default=False,
             help="Save the graphviz dot file used to generate the graph.",
+        )
+
+        self.parser.add_argument(
+            "--collapsible-nodes",
+            dest="collapsible_nodes",
+            action="store_true",
+            default=False,
+            help="Add collapse/expand buttons to play, role, and block nodes in the SVG output. Default: %(default)s",
         )
 
         self.parser.add_argument(

--- a/ansibleplaybookgrapher/cli.py
+++ b/ansibleplaybookgrapher/cli.py
@@ -419,6 +419,11 @@ class PlaybookGrapherCLI(CLI):
                 "The option --hide-empty-plays will be removed in the next major version (v3.0.0) to make it the default behavior.",
             )
 
+        if self.options.renderer != "graphviz" and self.options.collapsible_nodes:
+            display.warning(
+                "The option --collapsible-nodes is only available for the graphviz renderer. It will be ignored.",
+            )
+
         return options
 
     def validate_open_protocol_custom_formats(self) -> None:

--- a/ansibleplaybookgrapher/data/graph.css
+++ b/ansibleplaybookgrapher/data/graph.css
@@ -15,3 +15,8 @@
     stroke-width: 3;
     font-weight: bolder;
 }
+
+/* Hide elements when collapsed */
+.collapsed {
+    display: none;
+}

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -152,12 +152,13 @@ function setCollapsedRecursive(nodeId, collapse) {
             $(`g#${targetId}`).removeClass('collapsed');
             $(`g#${edgeId}`).removeClass('collapsed');
             $(`#collapse-btn-${targetId}`).removeClass('collapsed');
+            // Always reset the button text to '-' when expanding
+            $(`#collapse-btn-${targetId} text`).text('-');
         }
         // Recurse for the child node
         setCollapsedRecursive(targetId, collapse);
     });
 }
-
 /**
  * Collapse/Expand logic for play, block, and role nodes using <link> elements
  */

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -134,6 +134,50 @@ function dblClickElement(event) {
     }
 }
 
+/**
+ * Recursively hide/show all linked nodes and edges for a given node id
+ */
+function setCollapsedRecursive(nodeId, collapse) {
+    const nodeGroup = $(`g#${nodeId}`);
+    // Do NOT hide the button for the current node
+    const links = nodeGroup.find('link');
+    links.each(function (_, link) {
+        const targetId = $(link).attr('target');
+        const edgeId = $(link).attr('edge');
+        if (collapse) {
+            $(`g#${targetId}`).addClass('collapsed');
+            $(`g#${edgeId}`).addClass('collapsed');
+            $(`#collapse-btn-${targetId}`).addClass('collapsed');
+        } else {
+            $(`g#${targetId}`).removeClass('collapsed');
+            $(`g#${edgeId}`).removeClass('collapsed');
+            $(`#collapse-btn-${targetId}`).removeClass('collapsed');
+        }
+        // Recurse for the child node
+        setCollapsedRecursive(targetId, collapse);
+    });
+}
+
+/**
+ * Collapse/Expand logic for play, block, and role nodes using <link> elements
+ */
+function toggleRoleTasks(nodeId) {
+    // Find the collapse button
+    const btn = $(`#collapse-btn-${nodeId}`);
+    const btnText = btn.find('text');
+    let isCollapsed = false;
+    if (btnText.text() === '-') {
+        // Collapse: recursively hide all linked nodes and edges
+        setCollapsedRecursive(nodeId, true);
+        btnText.text('+');
+        isCollapsed = true;
+    } else {
+        // Expand: recursively show all linked nodes and edges
+        setCollapsedRecursive(nodeId, false);
+        btnText.text('-');
+        isCollapsed = false;
+    }
+}
 
 $("#svg").ready(function () {
     let playbooks = $("g[id^=playbook_]");
@@ -166,4 +210,10 @@ $("#svg").ready(function () {
     tasks.click(clickOnElement);
     tasks.dblclick(dblClickElement);
 
+    // Add collapse/expand button event
+    $(".collapse-btn").on('click', function (e) {
+        e.stopPropagation();
+        const nodeId = $(this).data('role-id');
+        toggleRoleTasks(nodeId);
+    });
 });

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -161,7 +161,7 @@ function setCollapsedRecursive(nodeId, collapse) {
 /**
  * Collapse/Expand logic for play, block, and role nodes using <link> elements
  */
-function toggleRoleTasks(nodeId) {
+function toggleNode(nodeId) {
     // Find the collapse button
     const btn = $(`#collapse-btn-${nodeId}`);
     const btnText = btn.find('text');
@@ -214,6 +214,6 @@ $("#svg").ready(function () {
     $(".collapse-btn").on('click', function (e) {
         e.stopPropagation();
         const nodeId = $(this).data('role-id');
-        toggleRoleTasks(nodeId);
+        toggleNode(nodeId);
     });
 });

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -213,7 +213,8 @@ $("#svg").ready(function () {
     // Add collapse/expand button event
     $(".collapse-btn").on('click', function (e) {
         e.stopPropagation();
-        const nodeId = $(this).data('role-id');
+        // Extract nodeId from the button's id
+        const nodeId = this.id.replace('collapse-btn-', '');
         toggleNode(nodeId);
     });
 });

--- a/ansibleplaybookgrapher/data/highlight-hover.js
+++ b/ansibleplaybookgrapher/data/highlight-hover.js
@@ -11,14 +11,15 @@ const HIGHLIGHT_CLASS = "highlight";
 
 /**
  * The current selected element on the graph
- * @type {null}
+ * @type {Element|null}
  */
 let currentSelectedElement = null;
 
 /**
  * Highlight the linked nodes of the given root element
- * @param {Element} parentElement
- * @param {string[]} visitedElements
+ * @param {Element} parentElement - The element whose linked nodes should be highlighted
+ * @param {string[]} visitedElements - Array of element IDs that have already been processed
+ * @returns {void}
  */
 function highlightLinkedNodes(parentElement, visitedElements = []) {
     $(parentElement).find('link').each(function (index, element) {
@@ -42,10 +43,11 @@ function highlightLinkedNodes(parentElement, visitedElements = []) {
 
 /**
  * Unhighlight the linked nodes of the given root element
- * @param {Element} parentElement
- * @param {string[]} visitedElements
- * @param {boolean} isHover True when we are coming from a mouseleave event. In that case, we should not unhighlight if
+ * @param {Element} parentElement - The element whose linked nodes should be unhighlighted
+ * @param {string[]} visitedElements - Array of element IDs that have already been processed
+ * @param {boolean} isHover - True when we are coming from a mouseleave event. In that case, we should not unhighlight if
  * the parentElement is the current selected element
+ * @returns {void}
  */
 function unHighlightLinkedNodes(parentElement, visitedElements = [], isHover) {
     const currentSelectedElementId = $(currentSelectedElement).attr('id');
@@ -78,7 +80,8 @@ function unHighlightLinkedNodes(parentElement, visitedElements = [], isHover) {
 
 /**
  * Hover handler for mouseenter event
- * @param {Event} event
+ * @param {MouseEvent} event - The mouseenter event
+ * @returns {void}
  */
 function hoverMouseEnter(event) {
     highlightLinkedNodes(event.currentTarget, []);
@@ -86,7 +89,8 @@ function hoverMouseEnter(event) {
 
 /**
  * Hover handler for mouseleave event
- * @param {Event} event
+ * @param {MouseEvent} event - The mouseleave event
+ * @returns {void}
  */
 function hoverMouseLeave(event) {
     unHighlightLinkedNodes(event.currentTarget, [], true);
@@ -94,7 +98,8 @@ function hoverMouseLeave(event) {
 
 /**
  * Handler when clicking on some elements
- * @param {Event} event
+ * @param {MouseEvent} event - The click event
+ * @returns {void}
  */
 function clickOnElement(event) {
     const newClickedElement = $(event.currentTarget);
@@ -121,7 +126,8 @@ function clickOnElement(event) {
 
 /**
  * Handler when double clicking on some elements
- * @param {Event} event
+ * @param {MouseEvent} event - The double click event
+ * @returns {void}
  */
 function dblClickElement(event) {
     const newElementDlbClicked = event.currentTarget;
@@ -136,6 +142,9 @@ function dblClickElement(event) {
 
 /**
  * Recursively hide/show all linked nodes and edges for a given node id
+ * @param {string} nodeId - The ID of the node to process
+ * @param {boolean} collapse - Whether to collapse (true) or expand (false) the node
+ * @returns {void}
  */
 function setCollapsedRecursive(nodeId, collapse) {
     const nodeGroup = $(`g#${nodeId}`);
@@ -161,6 +170,8 @@ function setCollapsedRecursive(nodeId, collapse) {
 }
 /**
  * Collapse/Expand logic for play, block, and role nodes using <link> elements
+ * @param {string} nodeId - The ID of the node to toggle
+ * @returns {void}
  */
 function toggleNode(nodeId) {
     // Find the collapse button

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -258,6 +258,7 @@ class GraphvizPlaybookBuilder(PlaybookBuilder):
         # BlockNode is a special node: a cluster is created instead of a normal node
         with digraph.subgraph(
             name=f"cluster_{block_node.id}",
+            graph_attr={"id": f"cluster_{block_node.id}"},
         ) as cluster_block_subgraph:
             # Prevents the cluster from having the root graph label (not needed)
             cluster_block_subgraph.attr(label="")

--- a/ansibleplaybookgrapher/renderer/graphviz/__init__.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/__init__.py
@@ -75,6 +75,7 @@ class GraphvizRenderer(Renderer):
         :return: The path of the rendered file.
         """
         save_dot_file = kwargs.get("save_dot_file", False)
+        collapsible_nodes = kwargs.get("collapsible_nodes", False)
 
         # Set of the roles that have been built so far for all the playbooks
         roles_built = set()
@@ -110,7 +111,9 @@ class GraphvizRenderer(Renderer):
 
         post_processor = GraphvizPostProcessor(svg_path=svg_path)
         display.v("Post processing the SVG...")
-        post_processor.post_process(self.playbook_nodes)
+        post_processor.post_process(
+            self.playbook_nodes, collapsible_nodes=collapsible_nodes
+        )
         post_processor.write()
 
         display.display(f"The graph has been exported to {svg_path}", color="green")

--- a/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
@@ -18,7 +18,7 @@ from ansible.utils.display import Display
 from lxml import etree
 from svg.path import parse_path
 
-from ansibleplaybookgrapher.graph_model import PlaybookNode
+from ansibleplaybookgrapher.graph_model import BlockNode, PlaybookNode
 
 display = Display()
 
@@ -147,7 +147,7 @@ class GraphvizPostProcessor:
             if xpath_result:
                 element = xpath_result[0]
                 links = etree.Element("links")
-                for counter, link in enumerate(node_links, 1):
+                for link in node_links:
                     links.append(
                         etree.Element(
                             "link",
@@ -157,6 +157,18 @@ class GraphvizPostProcessor:
                             },
                         ),
                     )
+
+                    if isinstance(link, BlockNode):
+                        # The link is a block, let's add a link to the Block subgraph so that is highlighted and collapsed
+                        links.append(
+                            etree.Element(
+                                "link",
+                                attrib={
+                                    "target": f"cluster_{link.id}",
+                                    "edge": f"edge_{node.id}-{link.id}",
+                                },
+                            ),
+                        )
 
                 element.append(links)
 

--- a/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
@@ -213,38 +213,51 @@ class GraphvizPostProcessor:
 
     def _add_collapse_buttons_and_data_attrs(self):
         # For each play, block, or role node, add a collapse/expand button (outside the group) for toggling
-        ns = {'svg': SVG_NAMESPACE}
-        for node_g in self.root.xpath(".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]", namespaces=ns):
-            node_id = node_g.get('id')
+        ns = {"svg": SVG_NAMESPACE}
+
+        for node_g in self.root.xpath(
+            ".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]",
+            namespaces=ns,
+        ):
+            node_id = node_g.get("id")
             # Find the first <text> element (the label)
-            text_elem = node_g.find('.//svg:text', namespaces=ns)
+            text_elem = node_g.find(".//svg:text", namespaces=ns)
             if text_elem is not None:
                 # Place the button above the label (y - 20)
-                x = float(text_elem.get('x', '0'))
-                y = float(text_elem.get('y', '0')) - 20
-                btn = etree.Element('g', attrib={
-                    'class': 'collapse-btn',
-                    'id': f'collapse-btn-{node_id}',
-                    'data-role-id': node_id
-                })
-                circle = etree.Element('circle', attrib={
-                    'cx': str(x),
-                    'cy': str(y),
-                    'r': '8',
-                    'fill': '#eee',
-                    'stroke': '#333',
-                    'stroke-width': '1',
-                })
+                x = float(text_elem.get("x", "0"))
+                y = float(text_elem.get("y", "0")) - 20
+                btn = etree.Element(
+                    "g",
+                    attrib={
+                        "class": "collapse-btn",
+                        "id": f"collapse-btn-{node_id}",
+                        "data-role-id": node_id,
+                    },
+                )
+                circle = etree.Element(
+                    "circle",
+                    attrib={
+                        "cx": str(x),
+                        "cy": str(y),
+                        "r": "8",
+                        "fill": "#eee",
+                        "stroke": "#333",
+                        "stroke-width": "1",
+                    },
+                )
                 btn.append(circle)
                 # Add a text label (+/-)
-                btn_text = etree.Element('text', attrib={
-                    'x': str(x),
-                    'y': str(y + 3),
-                    'text-anchor': 'middle',
-                    'font-size': '12',
-                    'fill': '#333',
-                })
-                btn_text.text = '-'
+                btn_text = etree.Element(
+                    "text",
+                    attrib={
+                        "x": str(x),
+                        "y": str(y + 3),
+                        "text-anchor": "middle",
+                        "font-size": "12",
+                        "fill": "#333",
+                    },
+                )
+                btn_text.text = "-"
                 btn.append(btn_text)
                 # Insert the button as a sibling after the node group
                 parent = node_g.getparent()

--- a/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
@@ -72,10 +72,14 @@ class GraphvizPostProcessor:
     def post_process(
         self,
         playbook_nodes: list[PlaybookNode] | None = None,
+        collapsible_nodes: bool = False,
         *args,
         **kwargs,
     ) -> None:
-        """:param playbook_nodes:
+        """
+        Post process the svg file by adding some javascript, css and hover effects.
+        :param playbook_nodes:
+        :param collapsible_nodes:
         :param args:
         :param kwargs:
         :return:
@@ -96,7 +100,7 @@ class GraphvizPostProcessor:
             cdata_text=_read_data("highlight-hover.js"),
         )
 
-        # insert my css
+        # insert my CSS
         self.insert_cdata(
             2,
             "style",
@@ -107,7 +111,9 @@ class GraphvizPostProcessor:
         # Curve the text on the edges
         self._curve_text_on_edges()
 
-        self._add_collapse_buttons_and_data_attrs()
+        # Add collapse/expand buttons only if requested
+        if collapsible_nodes:
+            self._add_collapse_buttons_and_data_attrs()
 
         playbook_nodes = playbook_nodes or []
         for p_node in playbook_nodes:
@@ -212,7 +218,7 @@ class GraphvizPostProcessor:
             text_element.text = None
 
     def _add_collapse_buttons_and_data_attrs(self):
-        # For each play, block, or role node, add a collapse/expand button (outside the group) for toggling
+        """For each play, block, or role node, add a collapse/expand button (outside the group) for toggling"""
         ns = {"svg": SVG_NAMESPACE}
         for node_g in self.root.xpath(
             ".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]",

--- a/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
@@ -213,37 +213,46 @@ class GraphvizPostProcessor:
 
     def _add_collapse_buttons_and_data_attrs(self):
         # For each play, block, or role node, add a collapse/expand button (outside the group) for toggling
-        ns = {'svg': SVG_NAMESPACE}
-        for node_g in self.root.xpath(".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]", namespaces=ns):
-            node_id = node_g.get('id')
+        ns = {"svg": SVG_NAMESPACE}
+        for node_g in self.root.xpath(
+            ".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]",
+            namespaces=ns,
+        ):
+            node_id = node_g.get("id")
             # Find the first <text> element (the label)
-            text_elem = node_g.find('.//svg:text', namespaces=ns)
+            text_elem = node_g.find(".//svg:text", namespaces=ns)
             if text_elem is not None:
                 # Place the button above the label (y - 20)
-                x = float(text_elem.get('x', '0'))
-                y = float(text_elem.get('y', '0')) - 20
-                btn = etree.Element('g', attrib={
-                    'class': 'collapse-btn',
-                    'id': f'collapse-btn-{node_id}'
-                })
-                circle = etree.Element('circle', attrib={
-                    'cx': str(x),
-                    'cy': str(y),
-                    'r': '8',
-                    'fill': '#eee',
-                    'stroke': '#333',
-                    'stroke-width': '1',
-                })
+                x = float(text_elem.get("x", "0"))
+                y = float(text_elem.get("y", "0")) - 20
+                btn = etree.Element(
+                    "g",
+                    attrib={"class": "collapse-btn", "id": f"collapse-btn-{node_id}"},
+                )
+                circle = etree.Element(
+                    "circle",
+                    attrib={
+                        "cx": str(x),
+                        "cy": str(y),
+                        "r": "8",
+                        "fill": "#eee",
+                        "stroke": "#333",
+                        "stroke-width": "1",
+                    },
+                )
                 btn.append(circle)
                 # Add a text label (+/-)
-                btn_text = etree.Element('text', attrib={
-                    'x': str(x),
-                    'y': str(y + 3),
-                    'text-anchor': 'middle',
-                    'font-size': '12',
-                    'fill': '#333',
-                })
-                btn_text.text = '-'
+                btn_text = etree.Element(
+                    "text",
+                    attrib={
+                        "x": str(x),
+                        "y": str(y + 3),
+                        "text-anchor": "middle",
+                        "font-size": "12",
+                        "fill": "#333",
+                    },
+                )
+                btn_text.text = "-"
                 btn.append(btn_text)
                 # Insert the button as a sibling after the node group
                 parent = node_g.getparent()

--- a/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
+++ b/ansibleplaybookgrapher/renderer/graphviz/postprocessor.py
@@ -213,51 +213,37 @@ class GraphvizPostProcessor:
 
     def _add_collapse_buttons_and_data_attrs(self):
         # For each play, block, or role node, add a collapse/expand button (outside the group) for toggling
-        ns = {"svg": SVG_NAMESPACE}
-
-        for node_g in self.root.xpath(
-            ".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]",
-            namespaces=ns,
-        ):
-            node_id = node_g.get("id")
+        ns = {'svg': SVG_NAMESPACE}
+        for node_g in self.root.xpath(".//svg:g[starts-with(@id, 'role_') or starts-with(@id, 'play_') or starts-with(@id, 'block_')]", namespaces=ns):
+            node_id = node_g.get('id')
             # Find the first <text> element (the label)
-            text_elem = node_g.find(".//svg:text", namespaces=ns)
+            text_elem = node_g.find('.//svg:text', namespaces=ns)
             if text_elem is not None:
                 # Place the button above the label (y - 20)
-                x = float(text_elem.get("x", "0"))
-                y = float(text_elem.get("y", "0")) - 20
-                btn = etree.Element(
-                    "g",
-                    attrib={
-                        "class": "collapse-btn",
-                        "id": f"collapse-btn-{node_id}",
-                        "data-role-id": node_id,
-                    },
-                )
-                circle = etree.Element(
-                    "circle",
-                    attrib={
-                        "cx": str(x),
-                        "cy": str(y),
-                        "r": "8",
-                        "fill": "#eee",
-                        "stroke": "#333",
-                        "stroke-width": "1",
-                    },
-                )
+                x = float(text_elem.get('x', '0'))
+                y = float(text_elem.get('y', '0')) - 20
+                btn = etree.Element('g', attrib={
+                    'class': 'collapse-btn',
+                    'id': f'collapse-btn-{node_id}'
+                })
+                circle = etree.Element('circle', attrib={
+                    'cx': str(x),
+                    'cy': str(y),
+                    'r': '8',
+                    'fill': '#eee',
+                    'stroke': '#333',
+                    'stroke-width': '1',
+                })
                 btn.append(circle)
                 # Add a text label (+/-)
-                btn_text = etree.Element(
-                    "text",
-                    attrib={
-                        "x": str(x),
-                        "y": str(y + 3),
-                        "text-anchor": "middle",
-                        "font-size": "12",
-                        "fill": "#333",
-                    },
-                )
-                btn_text.text = "-"
+                btn_text = etree.Element('text', attrib={
+                    'x': str(x),
+                    'y': str(y + 3),
+                    'text-anchor': 'middle',
+                    'font-size': '12',
+                    'fill': '#333',
+                })
+                btn_text.text = '-'
                 btn.append(btn_text)
                 # Insert the button as a sibling after the node group
                 parent = node_g.getparent()

--- a/tests/test_graph_model.py
+++ b/tests/test_graph_model.py
@@ -92,8 +92,6 @@ def test_links_structure_with_handlers() -> None:
         "Handler 3 should be linked to handler 1"
     )
 
-    print(all_links)
-
 
 def test_empty_play_method() -> None:
     """Testing the emptiness of a play

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -323,8 +323,9 @@ def test_include_role(
 def test_with_block(request: pytest.FixtureRequest) -> None:
     """Test with_block.yml, an example with roles."""
     svg_path, playbook_paths = run_grapher(
-        ["with_block.yml"], output_filename=request.node.name,
-        additional_args=["--collapsible-nodes"]
+        ["with_block.yml"],
+        output_filename=request.node.name,
+        additional_args=["--collapsible-nodes"],
     )
 
     _common_tests(

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -323,7 +323,8 @@ def test_include_role(
 def test_with_block(request: pytest.FixtureRequest) -> None:
     """Test with_block.yml, an example with roles."""
     svg_path, playbook_paths = run_grapher(
-        ["with_block.yml"], output_filename=request.node.name
+        ["with_block.yml"], output_filename=request.node.name,
+        additional_args=["--collapsible-nodes"]
     )
 
     _common_tests(

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -880,3 +880,58 @@ def test_only_roles_with_nested_include_roles_with_a_tag(
         blocks_number=1,
         roles_number=1,
     )
+
+
+@pytest.mark.parametrize(
+    ("flag", "expected_buttons"),
+    [("--", 0), ("--collapsible-nodes", 6)],
+    ids=["no_collapsible_nodes", "with_collapsible_nodes"],
+)
+def test_collapsible_nodes(
+    request: pytest.FixtureRequest,
+    flag: str,
+    expected_buttons: int,
+) -> None:
+    """Test the --collapsible-nodes flag.
+
+    When the flag is used, collapse/expand buttons should be added to play, block, and role nodes.
+    """
+    svg_path, playbook_paths = run_grapher(
+        ["with_block.yml"], output_filename=request.node.name, additional_args=[flag]
+    )
+
+    # First run common tests to verify the basic structure (same as test_with_block)
+    _common_tests(
+        svg_filename=svg_path,
+        playbook_paths=playbook_paths,
+        plays_number=1,
+        tasks_number=7,
+        post_tasks_number=2,
+        roles_number=1,
+        pre_tasks_number=1,
+        blocks_number=4,
+    )
+
+    # Check for collapse buttons
+    pq = PyQuery(filename=svg_path)
+    pq.remove_namespaces()
+
+    # Find collapse buttons in SVG
+    collapse_buttons = pq("g.collapse-btn")
+
+    # Verify the expected number of buttons (1 play + 4 blocks + 1 role = 6 buttons)
+    assert len(collapse_buttons) == expected_buttons, (
+        f"The SVG should contain {expected_buttons} collapse button(s) but found {len(collapse_buttons)}"
+    )
+
+    # Verify the structure of buttons when they exist
+    assert collapse_buttons.find("circle").length == expected_buttons, (
+        "Each collapse button should have a circle element"
+    )
+    assert collapse_buttons.find("text").length == expected_buttons, (
+        "Each collapse button should have a text element"
+    )
+
+    # Check that all text elements in buttons have the correct content
+    for text_elem in collapse_buttons.find("text"):
+        assert PyQuery(text_elem).text() == "-", "The default button text should be '-'"

--- a/tests/test_graphviz_renderer.py
+++ b/tests/test_graphviz_renderer.py
@@ -173,7 +173,7 @@ def _common_tests(
         + handlers_number
         + additional_edges_number
     )
-    print(f"Found Edges: {len(edges)}")
+
     assert len(edges) == expected_edges_number, (
         f"The graph should contains {expected_edges_number} edges but we found {len(edges)} edges."
     )


### PR DESCRIPTION
## Summary

This PR implements collapsible nodes in the SVG output for the Ansible Playbook Grapher, addressing [issue #77](https://github.com/haidaraM/ansible-playbook-grapher/issues/77).

## Feature Details
- Adds a collapse/expand button to all role, play, and block nodes in the SVG output.
- Clicking the button hides or shows all descendant nodes and edges recursively, making large graphs easier to navigate.
- The button is always visible for the current node, so users can always expand collapsed nodes.
- The implementation uses the existing `<link>` structure in the SVG to determine which nodes and edges to hide/show, with no extra attributes required.
- The code is generalized for all node types (role, play, block).
- Added a new CLI flag `--collapsible-nodes` to make this feature optional (disabled by default).

## Usage
- Generate an SVG with the `--collapsible-nodes` flag: `ansibleplaybookgrapher my_playbook.yml --collapsible-nodes`
- Open it in a browser and use the +/- buttons on plays, roles, and blocks to expand/collapse sections of the graph.

## Screenshots
- When using the flag, each play, block, and role node has a collapse/expand button.
- Clicking the button toggles visibility of all descendant nodes and edges recursively.
- The button's text changes from "-" to "+" when collapsed and back to "-" when expanded.

![node-collapsing](https://github.com/user-attachments/assets/8fc83d89-7e6b-4e93-85f2-47476a783e75)
